### PR TITLE
Make the codebase build and run on macOS (arm64, Apple clang)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+*.o
+*.a
+zebra
+scrzebra
+booktool
+practice
+enddev
+tune8dbs
+current.gam
+current.mov
+*.log

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,12 @@ TUNE8DBS_EXE	=	tune8dbs
 
 # --- Libraries
 
+UNAME_S		:= $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+LDFLAGS		= -lm -lz
+else
 LDFLAGS		= -static -lm -lz
+endif
 #LDFLAGS	= -static -lm -lz -Wl,-Map,map.out
 
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ Othello program created by Gunnar Andersson
 
 This repository has started by uploading original code, as of 2014/04/29, by Gunnar Andersson
 
+The code in this repository has since been modified (e.g. ported to macOS,
+directory structure reorganized). If you want the original files as uploaded,
+get the source from the `original` tag:
+
+```
+git checkout original
+```
+
 ## Web sites
 
 * Gunner's website: http://radagast.se/othello/

--- a/game.c
+++ b/game.c
@@ -16,7 +16,7 @@
 
 
 
-#if !defined( _WIN32_WCE ) && !defined( __linux__ ) && !defined( __CYGWIN__ )
+#if !defined( _WIN32_WCE ) && !defined( __linux__ ) && !defined( __CYGWIN__ ) && !defined( __APPLE__ )
 #include "dir.h"
 #endif
 
@@ -24,6 +24,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#if defined( __APPLE__ ) || defined( __linux__ ) || defined( __CYGWIN__ )
+#include <unistd.h>
+#endif
 
 #ifndef _WIN32_WCE
 #include <assert.h>

--- a/getcoeff.c
+++ b/getcoeff.c
@@ -1045,7 +1045,7 @@ init_coeffs( void ) {
 
 static long long int
 rdtsc( void ) {
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__i386__)
   long long a;
   asm volatile("rdtsc":"=A" (a));
   return a;

--- a/macros.h
+++ b/macros.h
@@ -43,7 +43,7 @@ extern "C" {
 
 
 /* Define function attributes directive when available */
-#if __GNUC__ >= 3
+#if __GNUC__ >= 3 && defined(__i386__)
 #define	REGPARM(num)	__attribute__((regparm(num)))
 #else
 #if defined (_MSC_VER) || defined(__BORLANDC__)

--- a/timer.c
+++ b/timer.c
@@ -16,7 +16,7 @@
 /* CRON_SUPPORTED should be enabled when Zebra is compiled for
    a Unix system which supports the Cron daemon. */
 
-#ifdef __linux__
+#if defined( __linux__ ) || defined( __APPLE__ )
 #define CRON_SUPPORTED
 #endif
 

--- a/zebra.c
+++ b/zebra.c
@@ -94,7 +94,7 @@ static int wld_skill[3], exact_skill[3];
 static char *log_file_name;
 static double player_time[3], player_increment[3];
 static int skill[3];
-static int wait;
+static int wait_flag;
 static int use_book = DEFAULT_USE_BOOK;
 static int wld_only = DEFAULT_WLD_ONLY;
 static int use_learning;
@@ -176,7 +176,7 @@ main( int argc, char *argv[] ) {
 #endif
 
   use_random = DEFAULT_RANDOM;
-  wait = DEFAULT_WAIT;
+  wait_flag = DEFAULT_WAIT;
   echo = DEFAULT_ECHO;
   display_pv = DEFAULT_DISPLAY_PV;
   use_learning = FALSE;
@@ -264,7 +264,7 @@ main( int argc, char *argv[] ) {
 	help = TRUE;
 	continue;
       }
-      wait = atoi( argv[arg_index] );
+      wait_flag = atoi( argv[arg_index] );
     }
     else if ( !strcasecmp( argv[arg_index], "-p" ) ) {
       if ( ++arg_index == argc ) {
@@ -984,7 +984,7 @@ play_game( const char *file_name,
 
       (void) choose_thor_opening_move( board, side_to_move, echo );
 
-      if ( echo && wait )
+      if ( echo && wait_flag )
 	dumpch();
       if ( disks_played >= provided_move_count ) {
 	if ( skill[side_to_move] == 0 ) {
@@ -1259,7 +1259,7 @@ analyze_game( const char *move_string ) {
 
       (void) choose_thor_opening_move( board, side_to_move, echo );
 
-      if ( echo && wait )
+      if ( echo && wait_flag )
 	dumpch();
 
       start_move( player_time[side_to_move],


### PR DESCRIPTION
Make the codebase build and run on macOS (arm64, Apple clang). The code previously assumed 32-bit x86 Linux/Windows.

## Portability fixes
- **macros.h**: only use the `regparm` calling-convention attribute on 32-bit x86; it is not valid on arm64
- **getcoeff.c**: gate the `rdtsc` inline assembly (x86 cycle counter) to `__i386__`; other platforms use the existing fallback
- **game.c**: skip the DOS-era `dir.h` include on macOS and include `<unistd.h>` for `getcwd()`
- **timer.c**: use the Unix `gettimeofday` timing path on macOS instead of `<windows.h>` / `GetTickCount()`
- **zebra.c**: rename the global variable `wait` to `wait_flag`; it collided with `wait()` from the macOS system headers
- **Makefile**: drop `-static` on Darwin (unsupported by Apple's linker); Linux builds are unchanged

## Housekeeping
- Add `.gitignore` for build artifacts
- README: point readers to the `original` tag for the unmodified upstream source

Verified on macOS 15 / Apple clang 21: all six targets build, and `zebra` plays a full self-play game loading `book.bin` and `coeffs2.bin`.