### PR TITLE
Remove stale Modified dates from file headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@
 #
 #  Created:       July 2, 1997
 #
-#  Modified:      December 25, 2005
-#
 
 
 # --- Directories ---

--- a/src/autop.c
+++ b/src/autop.c
@@ -3,8 +3,6 @@
 
    Created:       May 23, 1998
    
-   Modified:      May 2, 1999
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      An empty definition of functions from autoplay

--- a/src/autoplay.h
+++ b/src/autoplay.h
@@ -3,8 +3,6 @@
 
    Created:       May 21, 1998
    
-   Modified:      August 1, 2002
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:

--- a/src/bitbcnt.c
+++ b/src/bitbcnt.c
@@ -1,8 +1,6 @@
 /*
    File:          bitbcnt.c
 
-   Modified:      November 24, 2005
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
 		  Toshihiko Okuhara
 

--- a/src/bitbcnt.h
+++ b/src/bitbcnt.h
@@ -3,8 +3,6 @@
 
    Created:       November 22, 1999
    
-   Modified:      November 24, 2005
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:

--- a/src/bitbmob.c
+++ b/src/bitbmob.c
@@ -1,8 +1,6 @@
 /*
    File:          bitbmob.c
 
-   Modified:      November 18, 2005
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
 	          Toshihiko Okuhara
 

--- a/src/bitbmob.h
+++ b/src/bitbmob.h
@@ -3,8 +3,6 @@
 
    Created:       November 22, 1999
    
-   Modified:      December 25, 2002
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:

--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -3,8 +3,6 @@
 
    Created:       November 21, 1999
    
-   Modified:      November 24, 2005
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
                   Toshihiko Okuhara
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -3,8 +3,6 @@
 
    Created:       November 21, 1999
    
-   Modified:      November 24, 2005
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
                   Toshihiko Okuhara
 

--- a/src/bitbtest.c
+++ b/src/bitbtest.c
@@ -1,8 +1,6 @@
 /*
    File:          bitbtest.c
 
-   Modified:      November 24, 2005
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
 	          Toshihiko Okuhara
 

--- a/src/bitbtest.h
+++ b/src/bitbtest.h
@@ -3,8 +3,6 @@
 
    Created:       November 22, 1999
    
-   Modified:      November 24, 2005
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:

--- a/src/booktool.c
+++ b/src/booktool.c
@@ -3,8 +3,6 @@
 
    Created:      December 31, 1997
 
-   Modified:     December 30, 2004
-   
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:     The interface to the book manipulation module.

--- a/src/constant.h
+++ b/src/constant.h
@@ -3,8 +3,6 @@
 
    Created:      July 10, 1997
 
-   Modified:     September 14, 2002
-
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:     Some globally used constants.

--- a/src/counter.c
+++ b/src/counter.c
@@ -3,8 +3,6 @@
 
    Created:       March 29, 1999
 
-   Modified:      June 27, 1999
-   
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The counter code. The current implementation is

--- a/src/counter.h
+++ b/src/counter.h
@@ -3,8 +3,6 @@
 
    Created:       March 29, 1999
 
-   Modified:      December 25, 1999
-   
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The interface to the counter code.

--- a/src/display.c
+++ b/src/display.c
@@ -3,8 +3,6 @@
 
    Created:        July 10, 1997
 
-   Modified:       November 23, 2001
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       Some I/O routines.

--- a/src/display.h
+++ b/src/display.h
@@ -3,8 +3,6 @@
 
    Created:      July 10, 1997
 
-   Modified:     November 17, 2002
-
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:     Declarations of the screen output functions.

--- a/src/doflip.c
+++ b/src/doflip.c
@@ -1,8 +1,6 @@
 /*
    File:          doflip.c
 
-   Modified:      November 15, 2005
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
 	          Toshihiko Okuhara
 

--- a/src/end.c
+++ b/src/end.c
@@ -3,8 +3,6 @@
 
    Created:       1994
    
-   Modified:      December 19, 2005
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The fast endgame solver.

--- a/src/end.h
+++ b/src/end.h
@@ -3,8 +3,6 @@
 
    Created:       June 25, 1997
 
-   Modified:      November 24, 2005
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The interface to the endgame solver.

--- a/src/enddev.c
+++ b/src/enddev.c
@@ -3,8 +3,6 @@
 
    Created:      September 1, 2002
    
-   Modified:
-
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:

--- a/src/error.c
+++ b/src/error.c
@@ -3,8 +3,6 @@
 
    Created:    June 13, 1998
    
-   Modified:   November 12, 2001
-
    Author:     Gunnar Andersson (gunnar@radagast.se)
 
    Contents:   The text-based error handler.

--- a/src/error.h
+++ b/src/error.h
@@ -3,8 +3,6 @@
 
    Created:    June 13, 1998
    
-   Modified:   August 1, 2002
-
    Author:     Gunnar Andersson (gunnar@radagast.se)
 
    Contents:   The interface to the error handler.

--- a/src/eval.c
+++ b/src/eval.c
@@ -3,8 +3,6 @@
 
    Created:        July 1, 1997
 
-   Modified:       September 22, 1999
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       Control mechanisms for board evaluation.

--- a/src/eval.h
+++ b/src/eval.h
@@ -3,8 +3,6 @@
 
    Created:        July 1, 1997
 
-   Modified:       September 15, 2001
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       The interface to the evaluation function.

--- a/src/game.c
+++ b/src/game.c
@@ -3,8 +3,6 @@
 
    Created:        September 20, 1997
 
-   Modified:       December 31, 2002
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       All the routines needed to play a game.

--- a/src/game.h
+++ b/src/game.h
@@ -3,8 +3,6 @@
 
    Created:       September 20, 1997
    
-   Modified:      December 31, 2002
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The interface to the game routines.

--- a/src/getcoeff.c
+++ b/src/getcoeff.c
@@ -3,8 +3,6 @@
 
    Created:       November 19, 1997
 
-   Modified:      January 3, 2003
-   
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      Unpacks the coefficient file, computes final-stage

--- a/src/getcoeff.h
+++ b/src/getcoeff.h
@@ -3,8 +3,6 @@
 
    Created:      November 20, 1997
 
-   Modified:     August 1, 2002
-   
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:

--- a/src/globals.c
+++ b/src/globals.c
@@ -3,8 +3,6 @@
 
    Created:    June 30, 1997
 
-   Modified:   October 30, 2001
-
    Author:     Gunnar Andersson (gunnar@radagast.se)
 
    Contents:   Global state variables.

--- a/src/globals.h
+++ b/src/globals.h
@@ -3,8 +3,6 @@
 
    Created:        June 30, 1997
 
-   Modified:       January 8, 2000
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       Global state variables.

--- a/src/hash.c
+++ b/src/hash.c
@@ -3,8 +3,6 @@
 
    Created:       June 29, 1997
 
-   Modified:      November 15, 2005
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 		  Toshihiko Okuhara
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -3,8 +3,6 @@
 
    Created:       June 29, 1997
 
-   Modified:      October 25, 2005
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 		  Toshihiko Okuhara
 

--- a/src/learn.c
+++ b/src/learn.c
@@ -3,8 +3,6 @@
 
    Created:    November 29, 1999
    
-   Modified:   April 29, 2002
-
    Author:     Gunnar Andersson (gunnar@radagast.se)
 
    Contents:   The learning module.

--- a/src/learn.h
+++ b/src/learn.h
@@ -3,8 +3,6 @@
 
    Created:       November 29, 1997
    
-   Modified:      November 18, 2001
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The interface to the learning module.

--- a/src/macros.h
+++ b/src/macros.h
@@ -3,8 +3,6 @@
 
    Created:       May 31, 1998
 
-   Modified:      November 14, 2005
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      Some globally used macros.

--- a/src/magic.h
+++ b/src/magic.h
@@ -3,8 +3,6 @@
 
    Created:      July 5, 1999
 
-   Modified:     December 25, 1999
-
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:     Magic numbers used to distinguish different versions

--- a/src/midgame.c
+++ b/src/midgame.c
@@ -3,8 +3,6 @@
 
    Created:       July 1, 1997
 
-   Modified:      November 23, 2002
-   
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      Search routines designated to be used in the

--- a/src/midgame.h
+++ b/src/midgame.h
@@ -3,8 +3,6 @@
 
    Created:       July 1, 1998
 
-   Modified:      August 1, 2002
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The midgame search driver.

--- a/src/moves.c
+++ b/src/moves.c
@@ -3,8 +3,6 @@
 
    Created:           June 30, 1997
 
-   Modified:          April 24, 2001
-   
    Author:            Gunnar Andersson (gunnar@radagast.se)
 
    Contents:          The move generator.

--- a/src/moves.h
+++ b/src/moves.h
@@ -3,8 +3,6 @@
 
    Created:        June 30, 1997
 
-   Modified:       August 1, 2002
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       The move generator's interface.

--- a/src/osfbook.c
+++ b/src/osfbook.c
@@ -3,8 +3,6 @@
 
    Created:        December 31, 1997
 
-   Modified:       December 30, 2004
-   
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       A module which implements the book algorithm which

--- a/src/osfbook.h
+++ b/src/osfbook.h
@@ -3,8 +3,6 @@
 
    Created:         December 31, 1997
 
-   Modified:        December 30, 2002
-   
    Author:          Gunnar Andersson (gunnar@radagast.se)
 
    Contents:        The interface to the book module.

--- a/src/patterns.c
+++ b/src/patterns.c
@@ -3,8 +3,6 @@
 
    Created:       July 4, 1997
 
-   Modified:      December 25, 1999
-   
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The patterns.

--- a/src/patterns.h
+++ b/src/patterns.h
@@ -3,8 +3,6 @@
 
    Created:        July 4, 1997
 
-   Modified:       August 1, 2002
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       The patterns.

--- a/src/pcstat.h
+++ b/src/pcstat.h
@@ -2,8 +2,6 @@
    pcstat.h
 
    Automatically created by CORRELAT on Tue Sep 07 19:41:49 1999
-
-   Modified December 25, 1999
 */
 
 

--- a/src/porting.h
+++ b/src/porting.h
@@ -3,8 +3,6 @@
 
    Created:      November 4, 2001
 
-   Modified:
-
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:     System-specific stuff.

--- a/src/practice.c
+++ b/src/practice.c
@@ -3,8 +3,6 @@
 
    Created:      January 29, 1998
    
-   Modified:     July 12, 1999
-
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:     A small utility which enables the user to browse

--- a/src/probcut.c
+++ b/src/probcut.c
@@ -3,8 +3,6 @@
 
    Created:       March 1, 1998
 
-   Modified:      November 24, 2002
-   
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The initialization of the Multi-ProbCut search parameters.

--- a/src/probcut.h
+++ b/src/probcut.h
@@ -3,8 +3,6 @@
 
    Created:       March 1, 1998
 
-   Modified:      November 23, 2002
-   
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The declaration of the Multi-Prob-Cut variables.

--- a/src/safemem.c
+++ b/src/safemem.c
@@ -3,8 +3,6 @@
 
    Created:         August 30, 1998
 
-   Modified:        November 1, 2000
-   
    Author:          Gunnar Andersson (gunnar@radagast.se)
 
    Contents:        Provides safer memory allocation than malloc().

--- a/src/safemem.h
+++ b/src/safemem.h
@@ -3,8 +3,6 @@
 
    Created:    August 30, 1998
    
-   Modified:   January 25, 2000
-
    Author:     Gunnar Andersson (gunnar@radagast.se)
 
    Contents:   The interface to the safer version of malloc.

--- a/src/scrzebra.c
+++ b/src/scrzebra.c
@@ -3,8 +3,6 @@
 
    Created:        November 17, 2001
    
-   Modified:
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:

--- a/src/search.c
+++ b/src/search.c
@@ -3,8 +3,6 @@
 
    Created:       July 1, 1997
 
-   Modified:      January 2, 2003
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      Common search routines and variables.

--- a/src/search.h
+++ b/src/search.h
@@ -3,8 +3,6 @@
 
    Created:       July 1, 1997
 
-   Modified:      August 1, 2002
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The interface to common search routines and variables.

--- a/src/stable.c
+++ b/src/stable.c
@@ -3,8 +3,6 @@
 
    Created:       March 20, 1999
 
-   Modified:      November 22, 2005
-
    Authors:       Gunnar Andersson (gunnar@radagast.se)
                   David John Summers
                   Toshihiko Okuhara

--- a/src/stable.h
+++ b/src/stable.h
@@ -3,8 +3,6 @@
 
    Created:       March 20, 1999
 
-   Modified:      August 1, 2002
-   
    Authors:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      Interface to the code which conservatively estimates

--- a/src/texts.h
+++ b/src/texts.h
@@ -3,8 +3,6 @@
 
    Created:      September 22, 1999
 
-   Modified:     July 20, 2002
-
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:     All the string constants used in Zebra's output.

--- a/src/thordb.c
+++ b/src/thordb.c
@@ -3,8 +3,6 @@
 
    Created:       March 30, 1999
    
-   Modified:      October 6, 2002
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      An interface to the Thor database designed to

--- a/src/thordb.h
+++ b/src/thordb.h
@@ -3,8 +3,6 @@
 
    Created:       April 1, 1999
    
-   Modified:      August 24, 2002
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      An interface to the Thor database designed to

--- a/src/timer.c
+++ b/src/timer.c
@@ -3,8 +3,6 @@
 
    Created:      September 28, 1997
    
-   Modified:     November 13, 2001
-
    Author:       Gunnar Andersson (gunnar@radagast.se)
 
    Contents:     The time control mechanism.

--- a/src/timer.h
+++ b/src/timer.h
@@ -3,8 +3,6 @@
 
    Created:       September 28, 1997
    
-   Modified:      August 1, 2002
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The time control mechanism.

--- a/src/tune8dbs.c
+++ b/src/tune8dbs.c
@@ -3,8 +3,6 @@
 
    Created:       July 25, 1998
 
-   Modified:      December 20, 2001
-   
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      The database is analyzed with statistical methods;

--- a/src/unflip.c
+++ b/src/unflip.c
@@ -3,8 +3,6 @@
 
    Created:        February 26, 1999
    
-   Modified:       July 12, 1999
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       Low-level code to flip back the discs flipped by a move.

--- a/src/unflip.h
+++ b/src/unflip.h
@@ -3,8 +3,6 @@
 
    Created:       February 26, 1999
    
-   Modified:      December 25, 1999
-
    Author:        Gunnar Andersson (gunnar@radagast.se)
 
    Contents:      Low-level macro code to flip back the discs

--- a/src/zebra.c
+++ b/src/zebra.c
@@ -3,8 +3,6 @@
 
    Created:        June 5, 1997
    
-   Modified:       December 25, 2005
-
    Author:         Gunnar Andersson (gunnar@radagast.se)
 
    Contents:       The module which controls the operation of standalone Zebra.


### PR DESCRIPTION
Remove the `Modified:` line from every file header (66 files, plus `pcstat.h` which used a colon-less variant), along with the blank line that followed each.

These dates stopped being maintained in 2005 and no longer match when the files were actually last changed — git history is the authoritative record now. The rest of the header (`File:`, `Created:`, `Author:`, `Contents:`) is kept intact, preserving the original author attribution required by the GPL.

The diff is deletions only (132 lines); no code changes.
