### PR TITLE
Resolve all compilation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,8 @@ CXX		= g++
 DEFS =		-DINCLUDE_BOOKTOOL -DTEXT_BASED -DZLIB_STATIC
 
 WARNINGS =	-Wall -Wcast-align -Wwrite-strings -Wstrict-prototypes -Winline
-OPTS =		-O4 -s -fomit-frame-pointer -falign-functions=32
-#OPTS =		-O4 -s -fomit-frame-pointer -mtune=core2 -falign-functions=32
+OPTS =		-O3 -fomit-frame-pointer -falign-functions=32
+#OPTS =		-O3 -fomit-frame-pointer -mtune=core2 -falign-functions=32
 
 CFLAGS =	$(OPTS) $(WARNINGS) $(DEFS) -I$(SRCDIR) -MMD -MP
 CXXFLAGS =	$(CFLAGS)

--- a/src/bitbtest.c
+++ b/src/bitbtest.c
@@ -41,6 +41,11 @@ static const unsigned char left_contiguous[64] = {
 };
 
 static const unsigned int right_flip[7] = { 0x00000001u, 0x00000003u, 0x00000007u, 0x0000000Fu, 0x0000001Fu, 0x0000003Fu, 0x0000007Fu };
+/* Only referenced by the disabled alternative implementation of
+   bbFlips_Left_low below, hence marked unused. */
+#ifdef __GNUC__
+__attribute__(( unused ))
+#endif
 static const unsigned int left_flip[7]  = { 0x80000000u, 0xC0000000u, 0xE0000000u, 0xF0000000u, 0xF8000000u, 0xFC000000u, 0xFE000000u };
 static const unsigned int lsb_mask[4]   = { 0x000000FFu, 0x0000FFFFu, 0x00FFFFFFu, 0xFFFFFFFFu };
 static const unsigned int msb_mask[4]   = { 0xFF000000u, 0xFFFF0000u, 0xFFFFFF00u, 0xFFFFFFFFu };

--- a/src/booktool.c
+++ b/src/booktool.c
@@ -33,7 +33,6 @@ main( int argc, char *argv[] ) {
   char *statistics_file_name;
   char *opening_in_file;
   char *position_file;
-  char *opening_file;
   char *merge_script_file, *merge_output_file;
   char *export_file;
   char *merge_book_file;
@@ -97,7 +96,6 @@ main( int argc, char *argv[] ) {
   opening_in_file = NULL;
   dump_positions = FALSE;
   position_file = NULL;
-  opening_file = NULL;
   merge_script_file = NULL;
   merge_output_file = NULL;
   export_file = NULL;

--- a/src/game.c
+++ b/src/game.c
@@ -706,8 +706,8 @@ extended_compute_move( int side_to_move, int book_only,
       evaluated_list[index].pv[0] = unsearched_move[i];
 
       if ( empties > MAX( wld, exact ) ) {
-	transform1[i] = abs( my_random() );
-	transform2[i] = abs( my_random() );
+	transform1[i] = labs( my_random() );
+	transform2[i] = labs( my_random() );
       }
       else {
 	transform1[i] = 0;
@@ -1144,7 +1144,9 @@ compute_move( int side_to_move,
   FILE *log_file;
   EvaluationType book_eval_info, mid_eval_info, end_eval_info;
   char *eval_str;
+#if ADAPTIVE_SOLVE_DEPTH
   double midgame_diff;
+#endif
   enum { INTERRUPTED_MOVE, BOOK_MOVE, MIDGAME_MOVE, ENDGAME_MOVE } move_type;
   int i;
   int curr_move, midgame_move;
@@ -1381,11 +1383,13 @@ compute_move( int side_to_move,
       midgame_move = middle_game( side_to_move, midgame_depth,
 				  update_all, &mid_eval_info );
       set_current_eval( mid_eval_info );
+#if ADAPTIVE_SOLVE_DEPTH
       midgame_diff = 1.3 * mid_eval_info.score / 128.0;
       if ( side_to_move == BLACKSQ )
 	midgame_diff -= komi;
       else
 	midgame_diff += komi;
+#endif
       if ( timed_depth ) {  /* Check if the endgame zone has been reached */
 	offset = ENDGAME_OFFSET;
 

--- a/src/getcoeff.c
+++ b/src/getcoeff.c
@@ -1041,6 +1041,7 @@ init_coeffs( void ) {
 
 
 
+#if TIME_EVAL
 static long long int
 rdtsc( void ) {
 #if defined(__GNUC__) && defined(__i386__)
@@ -1051,6 +1052,7 @@ rdtsc( void ) {
   return 0;
 #endif
 }
+#endif
 
 
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -138,7 +138,7 @@ popcount( unsigned int b ) {
 static unsigned int
 get_closeness( unsigned int a0, unsigned int a1,
 	   unsigned int b0, unsigned int b1 ) {
-  return abs( popcount( a0 ^ b0 ) + popcount( a1 ^ b1 ) - 32 );
+  return abs( (int) ( popcount( a0 ^ b0 ) + popcount( a1 ^ b1 ) ) - 32 );
 }
 
 

--- a/src/midgame.c
+++ b/src/midgame.c
@@ -167,7 +167,7 @@ calculate_perturbation( void ) {
     shift = perturbation_amplitude / 2;
     for ( i = 0; i < 100; i++ )
       score_perturbation[i] =
-	(abs( my_random()) % perturbation_amplitude) - shift;
+	(labs( my_random()) % perturbation_amplitude) - shift;
   }
 }
 

--- a/src/myrandom.c
+++ b/src/myrandom.c
@@ -178,7 +178,7 @@ static  long		*my_end_ptr		= (long *) &my_randtbl[ DEG_3 + 1 ];
 int
 my_srandom(int x)
 {
-  int i, j;
+  int i;
 
   if (my_rand_type == TYPE_0)
   {
@@ -186,7 +186,6 @@ my_srandom(int x)
   }
   else
   {
-    j = 1;
     my_state[ 0 ] = x;
     for (i = 1; i < my_rand_deg; i++)
     {
@@ -266,7 +265,7 @@ my_initstate (unsigned seed, char *arg_state, int n)
       }
     }
   }
-  my_state = &(((long *)arg_state)[1]);	/* first location */
+  my_state = &(((long *)(void *)arg_state)[1]);	/* first location */
   my_end_ptr = &my_state[my_rand_deg];	/* must set end_ptr before srandom */
   my_srandom(seed);
   if (my_rand_type == TYPE_0)
@@ -291,7 +290,7 @@ my_initstate (unsigned seed, char *arg_state, int n)
 char  *
 my_setstate(char *arg_state)
 {
-  long *new_state = (long *)arg_state;
+  long *new_state = (long *)(void *)arg_state;
   int type = new_state[0]%MAX_TYPES;
   int rear = new_state[0]/MAX_TYPES;
   char *ostate = (char *)( &my_state[ -1 ] );

--- a/src/osfbook.c
+++ b/src/osfbook.c
@@ -1048,7 +1048,7 @@ endgame_correlation( int side_to_move, int best_score, int best_move,
   int eval_list[64];
 
   display_board( stdout, board, BLACKSQ, FALSE, FALSE, FALSE );
-  set_hash_transformation( abs( my_random() ), abs( my_random() ) );
+  set_hash_transformation( labs( my_random() ), labs( my_random() ) );
   determine_hash_values( side_to_move, board );
   for ( depth = 1; depth <= spec.max_depth; depth++ ) {
     (void) middle_game( side_to_move, depth, FALSE, &dummy_info );
@@ -3926,7 +3926,7 @@ check_forced_opening( int side_to_move, const char *opening ) {
      randomly to avoid the same symmetry being chosen all the time.
      This is not a perfect scheme but good enough. */
 
-  symmetry = abs( my_random() ) % 8;
+  symmetry = labs( my_random() ) % 8;
   for ( symm_index = 0; symm_index < 8;
 	symm_index++, symmetry = (symmetry + 1) % 8 ) {
     same_position = TRUE;

--- a/src/thordb.c
+++ b/src/thordb.c
@@ -761,9 +761,9 @@ player_lex_order( int index ) {
 static int
 read_prolog( FILE *stream, PrologType *prolog ) {
   int success;
-  int_8 byte_val;
-  int_16 word_val;
-  int_32 longint_val;
+  int_8 byte_val = 0;
+  int_16 word_val = 0;
+  int_32 longint_val = 0;
 
   success = get_int_8( stream, &byte_val );
   prolog->creation_century = byte_val;
@@ -1036,8 +1036,8 @@ static int
 read_game( FILE *stream, GameType *game ) {
   int success;
   int actually_read;
-  int_8 byte_val;
-  int_16 word_val;
+  int_8 byte_val = 0;
+  int_16 word_val = 0;
 
   success = get_int_16( stream, &word_val );
   game->tournament_no = word_val;
@@ -1139,7 +1139,7 @@ game_database_already_loaded( const char *file_name ) {
 	 && (current_db->prolog.creation_day == new_prolog.creation_day)
 	 && (current_db->prolog.game_count == new_prolog.game_count)
 	 && (current_db->prolog.item_count == new_prolog.item_count)
-	 &&(current_db->prolog.origin_year == current_db->prolog.origin_year) )
+	 && (current_db->prolog.origin_year == new_prolog.origin_year) )
       return TRUE;
     current_db = current_db->next;
   }
@@ -1810,7 +1810,7 @@ choose_thor_opening_move( int *in_board, int side_to_move, int echo ) {
   for ( i = 0; i < 8; i++ )
     symmetries[i] = i;
   for ( i = 0; i < 7; i++ ) {
-    j  = i + abs( my_random() ) % (8 - i);
+    j  = i + labs( my_random() ) % (8 - i);
     temp_symm = symmetries[i];
     symmetries[i] = symmetries[j];
     symmetries[j] = temp_symm;
@@ -1837,7 +1837,7 @@ choose_thor_opening_move( int *in_board, int side_to_move, int echo ) {
        randomly select one of them. Probability for each move is
        proportional to the frequency of that move being played here. */
 
-    random_value = abs( my_random() ) % freq_sum;
+    random_value = labs( my_random() ) % freq_sum;
     random_move = PASS;
     acc_freq_sum = 0;
     match_count = 0;
@@ -2492,12 +2492,12 @@ init_thor_hash( void ) {
 
   for ( i = 0; i < 8; i++ ) {
     for ( j = 0; j < 6561; j++ )
-      buffer[j] = abs( my_random() );
+      buffer[j] = labs( my_random() );
     for ( j = 0; j < 6561; j++ )
       primary_hash[i][j] = (buffer[j] & 0xFFFF0000) |
 	(bit_reverse_32( buffer[flip_row[j]] ) & 0x0000FFFF);
     for ( j = 0; j < 6561; j++ )
-      buffer[j] = abs( my_random() );
+      buffer[j] = labs( my_random() );
     for ( j = 0; j < 6561; j++ )
       secondary_hash[i][j] = (buffer[j] & 0xFFFF0000) |
 	(bit_reverse_32( buffer[flip_row[j]] ) & 0x0000FFFF);
@@ -2775,8 +2775,12 @@ build_thor_opening_tree( void ) {
 
 /*
   PRINT_THOR_OPENING_TREE
+  Debugging aid; not called from any production code path.
 */
 
+#ifdef __GNUC__
+__attribute__(( unused ))
+#endif
 static void
 print_thor_opening_tree( ThorOpeningNode *node, int depth ) {
   char move;

--- a/src/tune8dbs.c
+++ b/src/tune8dbs.c
@@ -348,7 +348,7 @@ void compute_patterns( void ) {
    Sorts an integer vector using bubble-sort.
 */
 
-INLINE
+static INLINE
 void sort( int *vec, int count ) {
   int i;
   int temp;
@@ -669,7 +669,7 @@ void determine_features( int side_to_move, int stage, int *global_parity,
 */   
 
 void perform_analysis( int index ) {
-  int coeff, start, stop;
+  int start, stop;
   int global_parity;
   int side_to_move, stage;
   int buffer_a[4], buffer_b[4], buffer_c[4], buffer_d[4];
@@ -693,7 +693,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 4) && (buffer_d[stop] == buffer_d[start]) )
       stop++;
-    coeff = stop - start;
     dfile[buffer_d[start]].frequency++;
     start = stop;
   } while (start < 4);
@@ -706,7 +705,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 4) && (buffer_c[stop] == buffer_c[start]) )
       stop++;
-    coeff = stop - start;
     cfile[buffer_c[start]].frequency++;
     start = stop;
   } while ( start < 4 );
@@ -719,7 +717,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 4) && (buffer_b[stop] == buffer_b[start]) )
       stop++;
-    coeff = stop - start;
     bfile[buffer_b[start]].frequency++;
     start = stop;
   } while ( start < 4 );
@@ -732,7 +729,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 4) && (buffer_a[stop] == buffer_a[start]) )
       stop++;
-    coeff = stop - start;
     if ( USE_A_FILE )
       afile[buffer_a[start]].frequency++;
     else if ( USE_A_FILE2X )
@@ -748,7 +744,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 2) && (buffer_8[stop] == buffer_8[start]) )
       stop++;
-    coeff = stop - start;
     diag8[buffer_8[start]].frequency++;
     start = stop;
   } while ( start < 2 );
@@ -761,7 +756,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 4) && (buffer_7[stop] == buffer_7[start]) )
       stop++;
-    coeff = stop - start;
     diag7[buffer_7[start]].frequency++;
     start = stop;
   } while ( start < 4 );
@@ -774,7 +768,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 4) && (buffer_6[stop] == buffer_6[start]) )
       stop++;
-    coeff = stop - start;
     diag6[buffer_6[start]].frequency++;
     start = stop;
   } while (start < 4 );
@@ -787,7 +780,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 4) && (buffer_5[stop] == buffer_5[start]) )
       stop++;
-    coeff = stop - start;
     diag5[buffer_5[start]].frequency++;
     start = stop;
   } while ( start < 4 );
@@ -800,7 +792,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 4) && (buffer_4[stop] == buffer_4[start]) )
       stop++;
-    coeff = stop - start;
     diag4[buffer_4[start]].frequency++;
     start = stop;
   } while ( start < 4 );
@@ -813,7 +804,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 8) && (buffer_52[stop] == buffer_52[start]) )
       stop++;
-    coeff = stop - start;
     corner52[buffer_52[start]].frequency++;
     start = stop;
   } while ( start < 8 );
@@ -826,7 +816,6 @@ void perform_analysis( int index ) {
     stop = start + 1;
     while ( (stop < 4) && (buffer_33[stop] == buffer_33[start]) )
       stop++;
-    coeff = stop - start;
     corner33[buffer_33[start]].frequency++;
     start = stop;
   } while ( start < 4 );
@@ -1068,7 +1057,7 @@ void perform_step_update( int index ) {
    A wrapper to the function given by the function pointer BFUNC.
 */
 
-INLINE
+static INLINE
 void perform_action( void (*bfunc)(int), int index ) {
   node_count++;
   if ( active[position_list[index].stage] ) {
@@ -1736,7 +1725,6 @@ int main(int argc, char *argv[]) {
   double grad_sum, old_grad_sum;
   int i;
   int iteration, max_iterations;
-  int count;
   time_t start_time, curr_time;
   FILE *option_stream;
 
@@ -1922,7 +1910,6 @@ int main(int argc, char *argv[]) {
     abs_error_sum = 0.0;
     printf( "\nDetermining gradient:      " );
     fflush( stdout );
-    count = 0;
     total_weight = 0.0;
     evaluate_games();
     printf( " %d\n", relevant_count );
@@ -2028,7 +2015,6 @@ int main(int argc, char *argv[]) {
 
     printf("Determining step:          ");
     fflush(stdout);
-    count = 0;
     quad_coeff = 0.0;
     lin_coeff = 0.0;
     const_coeff = 0.0;

--- a/src/zebra.c
+++ b/src/zebra.c
@@ -146,7 +146,9 @@ Interprets the command-line parameters and starts the game.
 
 int
 main( int argc, char *argv[] ) {
+#if !SCRIPT_ONLY
   const char *game_file_name = NULL;
+#endif
   const char *script_in_file;
   const char *script_out_file;
 #if !SCRIPT_ONLY
@@ -162,7 +164,9 @@ main( int argc, char *argv[] ) {
 #endif
   int run_script;
   int script_optimal_line = DEFAULT_DISPLAY_LINE;
+#if SCRIPT_ONLY
   int komi;
+#endif
   time_t timer;
 
 #if SCRIPT_ONLY
@@ -181,11 +185,15 @@ main( int argc, char *argv[] ) {
   use_thor = DEFAULT_USE_THOR;
   skill[BLACKSQ] = skill[WHITESQ] = -1;
   hash_bits = DEFAULT_HASH_BITS;
+#if !SCRIPT_ONLY
   game_file_name = NULL;
+#endif
   log_file_name = NULL;
   run_script = FALSE;
   script_in_file = script_out_file = FALSE;
+#if SCRIPT_ONLY
   komi = 0;
+#endif
   player_time[BLACKSQ] = player_time[WHITESQ] = INFINIT_TIME;
   player_increment[BLACKSQ] = player_increment[WHITESQ] = 0.0;
   for ( arg_index = 1, help = FALSE; (arg_index < argc) && !help;


### PR DESCRIPTION
Eliminates every compiler and linker warning from a clean build with Apple clang on arm64 (previously ~90 warning lines). Two of the warnings turned out to be latent bugs.

## Bug fixes found via warnings

- **thordb.c** — a self-comparison typo: `origin_year == current_db->prolog.origin_year` compared a field to itself instead of to `new_prolog.origin_year`, so a Thor database differing only in origin year was treated as already loaded.
- **hash.c** — `get_closeness()` took `abs()` of an unsigned expression: when the popcount sum was under 32 the subtraction wrapped instead of yielding the intended distance. Now computed in signed arithmetic.

## Correctness / portability

- `abs( my_random() )` → `labs(...)` throughout (`my_random()` returns `long`; `abs` truncates where long is 64-bit)
- thordb.c: initialize `byte_val`/`word_val`/`longint_val` in the prolog/game readers (read while uninitialized on file-read failure paths)
- myrandom.c: route `char* → long*` casts through `void*` (callers pass aligned state)
- tune8dbs.c: make the prototype-less `INLINE` functions `static` — under C99 inline semantics no external definition was emitted, which broke linking at `-O0`

## Dead code removal / gating

- Gate `rdtsc()` behind `TIME_EVAL` and `midgame_diff` behind `ADAPTIVE_SOLVE_DEPTH`, matching their only consumers
- Declare `komi` / `game_file_name` only in the build variant (scrzebra vs zebra) that uses them
- Remove set-but-never-read variables (booktool.c `opening_file`, tune8dbs.c dead stores, myrandom.c `j`)
- Mark `left_flip[]` `__attribute__((unused))` — referenced only by a disabled alternative macro implementation, kept for reference

## Build flags

- `-O4` → `-O3` (clang treats them identically but warns) and drop obsolete `-s`

Verified: clean build with zero warnings at both `-O3` and `-O0`, `make test` passes (fliptest + FFO quick suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)