### PR TITLE
Use hardware popcount instructions

### DIFF
--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -29,6 +29,10 @@ BitBoard square_mask[100];
 
 INLINE unsigned int REGPARM(2)
 non_iterative_popcount( unsigned int n1, unsigned int n2 ) {
+#if defined( __GNUC__ )
+  /* Single hardware instruction on arm64 (cnt) and x86-64 (popcnt) */
+  return __builtin_popcountll( ((unsigned long long) n1 << 32) | n2 );
+#else
   n1 = n1 - ((n1 >> 1) & 0x55555555u);
   n2 = n2 - ((n2 >> 1) & 0x55555555u);
   n1 = (n1 & 0x33333333u) + ((n1 >> 2) & 0x33333333u);
@@ -36,6 +40,7 @@ non_iterative_popcount( unsigned int n1, unsigned int n2 ) {
   n1 = (n1 + (n1 >> 4)) & 0x0F0F0F0Fu;
   n2 = (n2 + (n2 >> 4)) & 0x0F0F0F0Fu;
   return ((n1 + n2) * 0x01010101u) >> 24;
+#endif
 }
 
 
@@ -50,6 +55,9 @@ non_iterative_popcount( unsigned int n1, unsigned int n2 ) {
 
 INLINE unsigned int REGPARM(2)
 iterative_popcount( unsigned int n1, unsigned int n2 ) {
+#if defined( __GNUC__ )
+  return __builtin_popcountll( ((unsigned long long) n1 << 32) | n2 );
+#else
   unsigned int n;
   n = 0;
   for ( ; n1 != 0; n++, n1 &= (n1 - 1) )
@@ -58,6 +66,7 @@ iterative_popcount( unsigned int n1, unsigned int n2 ) {
     ;
 
   return n;
+#endif
 }
 
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -118,12 +118,16 @@ resize_hash( int new_hash_bits ) {
 
 static unsigned int
 popcount( unsigned int b ) {
+#if defined( __GNUC__ )
+  return __builtin_popcount( b );
+#else
   unsigned int n;
 
   for ( n = 0; b != 0; n++, b &= (b - 1) )
     ;
 
   return n;
+#endif
 }
 
 


### PR DESCRIPTION
Replaces bitwise shift/loop popcount functions with GCC/Clang built-ins (__builtin_popcountll / __builtin_popcount) to leverage hardware popcount instructions on x86-64 and arm64.