### PR TITLE
Tune the endgame stability cutoff thresholds

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -135,8 +135,15 @@ static const double end_percentile[MAX_SELECTIVITY + 1] =
 
 #if USE_STABILITY
 #define  HIGH_STABILITY_THRESHOLD     24
-static const int stability_threshold[] = { 65, 65, 65, 65, 65, 46, 38, 30, 24,
-				           24, 24, 24, 0, 0, 0, 0, 0, 0, 0 };
+/* Alpha above which a stability cutoff is attempted, indexed by the
+   number of empty squares.  Proving a bound costs a stability count, so
+   it only pays when alpha is already high enough that few discs need to
+   be stable; the more empties remain, the higher that bar has to be.
+   Below 5 empties the specialized solvers take over and never consult
+   this table.  Tuned as 2 * empties on FFO #45/#48/#49/#51. */
+static const int stability_threshold[] = { 65, 65, 65, 65, 65, 10, 12, 14, 16,
+					   18, 20, 22, 24, 26, 28, 30, 32, 34,
+					   36 };
 #endif
 
 


### PR DESCRIPTION
The endgame solvers already attempted a stability cutoff once alpha reached stability_threshold[empties], but the table was shaped the wrong way round: it demanded a very high alpha with few empties left (46 at 5 empties) and then dropped to 0 at 12, where every node with a non-negative alpha paid for a full stability count.

Proving a bound costs a stability count, so the attempt only pays when alpha is already high enough that few discs need to be stable -- and the more empties remain, the higher that bar has to be. The table now rises with the number of empty squares (2 * empties), which is both monotone in the right direction and cheaper to justify.

Swept several shapes on FFO #45/#48/#49/#51; 2 * empties matched the best table found and beat more and less aggressive variants. Measured against the previous behaviour: #48 about 30% faster, #49 about 8%, #51 about 2%, #45 unchanged, none slower. Exact scores and best moves are unchanged on all four, and make test passes.