### PR TITLE
Make the search state thread-local

### DIFF
--- a/src/bitbtest.c
+++ b/src/bitbtest.c
@@ -16,7 +16,7 @@
 #include "bitboard.h"
 
 
-BitBoard bb_flips;
+_Thread_local BitBoard bb_flips;
 
 static const unsigned char right_contiguous[64] = {
   0, 1, 0, 2, 0, 1, 0, 3,

--- a/src/bitbtest.h
+++ b/src/bitbtest.h
@@ -20,7 +20,7 @@
 
 
 
-extern BitBoard bb_flips;
+extern _Thread_local BitBoard bb_flips;
 
 extern int (REGPARM(2) * const TestFlips_bitboard[78])(unsigned int, unsigned int, unsigned int, unsigned int);
 

--- a/src/doflip.c
+++ b/src/doflip.c
@@ -30,7 +30,7 @@
 
 /* Global variables */
 
-unsigned int hash_update1, hash_update2;
+_Thread_local unsigned int hash_update1, hash_update2;
 
 
 

--- a/src/doflip.h
+++ b/src/doflip.h
@@ -14,7 +14,7 @@
 #include "macros.h"
 
 
-extern unsigned int hash_update1, hash_update2;
+extern _Thread_local unsigned int hash_update1, hash_update2;
 
 
 

--- a/src/end.c
+++ b/src/end.c
@@ -113,13 +113,13 @@ typedef enum {
 
 
 
-MoveLink end_move_list[100];
+_Thread_local MoveLink end_move_list[100];
 
 
 
 /* The parities of the regions are in the region_parity bit vector. */
 
-static unsigned int region_parity;
+static _Thread_local unsigned int region_parity;
 
 /* Pseudo-probabilities corresponding to the percentiles.
    These are taken from the normal distribution; to the percentile
@@ -150,7 +150,7 @@ static const int stability_threshold[] = { 65, 65, 65, 65, 65, 10, 12, 14, 16,
 
 static double fast_first_mean[61][64];
 static double fast_first_sigma[61][64];
-static int best_move, best_end_root_move;
+static _Thread_local int best_move, best_end_root_move;
 static int true_found, true_val;
 static int full_output_mode;
 static int earliest_wld_solve, earliest_full_solve;

--- a/src/end.h
+++ b/src/end.h
@@ -30,7 +30,7 @@ typedef struct  {
 } MoveLink;
 
 
-extern MoveLink end_move_list[100];
+extern _Thread_local MoveLink end_move_list[100];
 extern const unsigned int quadrant_mask[100];
 
 

--- a/src/game.c
+++ b/src/game.c
@@ -297,7 +297,7 @@ game_init( const char *file_name, int *side_to_move ) {
 
   reset_counter( &total_evaluations );
 
-  init_flip_stack();
+  init_search_thread();
 
   total_time = 0.0;
   max_depth_reached = 0;

--- a/src/getcoeff.c
+++ b/src/getcoeff.c
@@ -1066,7 +1066,7 @@ rdtsc( void ) {
 #include "display.h"
 #endif
 
-short pattern_score;
+_Thread_local short pattern_score;
 
 INLINE int
 pattern_evaluation( int side_to_move ) {

--- a/src/globals.c
+++ b/src/globals.c
@@ -15,10 +15,10 @@
 
 /* Global variables */
 
-int pv[MAX_SEARCH_DEPTH][MAX_SEARCH_DEPTH];
-int pv_depth[MAX_SEARCH_DEPTH];
+_Thread_local int pv[MAX_SEARCH_DEPTH][MAX_SEARCH_DEPTH];
+_Thread_local int pv_depth[MAX_SEARCH_DEPTH];
 int score_sheet_row;
-int piece_count[3][MAX_SEARCH_DEPTH];
+_Thread_local int piece_count[3][MAX_SEARCH_DEPTH];
 int black_moves[60];
 int white_moves[60];
-Board board;
+_Thread_local Board board;

--- a/src/globals.h
+++ b/src/globals.h
@@ -29,17 +29,17 @@ typedef int Board[128];
    node on recursion depth n on the current recursive call sequence.
    After the search, pv[0][0..<depth>] contains the principal
    variation from the root position. */
-extern int pv[MAX_SEARCH_DEPTH][MAX_SEARCH_DEPTH];
+extern _Thread_local int pv[MAX_SEARCH_DEPTH][MAX_SEARCH_DEPTH];
 
 /* pv_depth[n] contains the depth of the principal variation
    starting at level n in the call sequence.
    After the search, pv[0] holds the depth of the principal variation
    from the root position. */
-extern int pv_depth[MAX_SEARCH_DEPTH];
+extern _Thread_local int pv_depth[MAX_SEARCH_DEPTH];
 
 /* piece_count[col][n] holds the number of disks of color col after
    n moves have been played. */
-extern int piece_count[3][MAX_SEARCH_DEPTH];
+extern _Thread_local int piece_count[3][MAX_SEARCH_DEPTH];
 
 /* These variables hold the game score. The meaning is similar
    to how a human would fill out a game score except for that
@@ -50,7 +50,7 @@ extern int white_moves[60];
 
 /* Holds the current board position. Updated as the search progresses,
    but all updates must be reversed when the search stops. */
-extern Board board;
+extern _Thread_local Board board;
 
 
 #endif  /* GLOBALS_H */

--- a/src/hash.c
+++ b/src/hash.c
@@ -52,8 +52,8 @@ typedef struct {
 /* Global variables */
 
 int hash_size;
-unsigned int hash1;
-unsigned int hash2;
+_Thread_local unsigned int hash1;
+_Thread_local unsigned int hash2;
 unsigned int hash_value1[3][128];
 unsigned int hash_value2[3][128];
 unsigned int hash_put_value1[3][128];
@@ -66,8 +66,8 @@ unsigned int hash_flip_color1;
 unsigned int hash_flip_color2;
 unsigned int hash_diff1[MAX_SEARCH_DEPTH];
 unsigned int hash_diff2[MAX_SEARCH_DEPTH];
-unsigned int hash_stored1[MAX_SEARCH_DEPTH];
-unsigned int hash_stored2[MAX_SEARCH_DEPTH];
+_Thread_local unsigned int hash_stored1[MAX_SEARCH_DEPTH];
+_Thread_local unsigned int hash_stored2[MAX_SEARCH_DEPTH];
 
 
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -58,8 +58,8 @@ typedef struct {
 extern int hash_size;
 
 /* The 64-bit hash key. */
-extern unsigned int hash1;
-extern unsigned int hash2;
+extern _Thread_local unsigned int hash1;
+extern _Thread_local unsigned int hash2;
 
 /* The 64-bit hash masks for a piece of a certain color in a
    certain position. */
@@ -88,8 +88,8 @@ extern unsigned int hash_flip_color2;
 
 /* Stored 64-bit hash mask which hold the hash codes at different nodes
    in the search tree. */
-extern unsigned int hash_stored1[MAX_SEARCH_DEPTH];
-extern unsigned int hash_stored2[MAX_SEARCH_DEPTH];
+extern _Thread_local unsigned int hash_stored1[MAX_SEARCH_DEPTH];
+extern _Thread_local unsigned int hash_stored2[MAX_SEARCH_DEPTH];
 
 
 

--- a/src/midgame.c
+++ b/src/midgame.c
@@ -72,17 +72,17 @@
 
 
 
-static int allow_midgame_hash_probe;
-static int allow_midgame_hash_update;
-static int best_mid_move, best_mid_root_move;
-static int midgame_abort;
-static int do_check_midgame_abort = TRUE;
-static int counter_phase;
-static int apply_perturbation = TRUE;
+static _Thread_local int allow_midgame_hash_probe;
+static _Thread_local int allow_midgame_hash_update;
+static _Thread_local int best_mid_move, best_mid_root_move;
+static _Thread_local int midgame_abort;
+static _Thread_local int do_check_midgame_abort = TRUE;
+static _Thread_local int counter_phase;
+static _Thread_local int apply_perturbation = TRUE;
 static int perturbation_amplitude = 0;
-static int stage_reached[61], stage_score[61];
+static _Thread_local int stage_reached[61], stage_score[61];
 static int score_perturbation[100];
-static int feas_index_list[64][64];
+static _Thread_local int feas_index_list[64][64];
 
 
 

--- a/src/moves.c
+++ b/src/moves.c
@@ -28,9 +28,9 @@
 
 /* Global variables */
 
-int disks_played;
-int move_count[MAX_SEARCH_DEPTH];
-int move_list[MAX_SEARCH_DEPTH][64];
+_Thread_local int disks_played;
+_Thread_local int move_count[MAX_SEARCH_DEPTH];
+_Thread_local int move_list[MAX_SEARCH_DEPTH][64];
 int *first_flip_direction[100];
 int flip_direction[100][16];   /* 100 * 9 used */
 int **first_flipped_disc[100];
@@ -52,8 +52,8 @@ const int move_offset[8] = { 1, -1, 9, -9, 10, -10, 11, -11 };
 
 /* Local variables */
 
-static int flip_count[65];
-static int sweep_status[MAX_SEARCH_DEPTH];
+static _Thread_local int flip_count[65];
+static _Thread_local int sweep_status[MAX_SEARCH_DEPTH];
 
 
 

--- a/src/moves.h
+++ b/src/moves.h
@@ -27,7 +27,7 @@ extern "C" {
 
 /* The number of disks played from the initial position.
    Must match the current status of the BOARD variable. */
-extern int disks_played;
+extern _Thread_local int disks_played;
 
 /* Holds the last move made on the board for each different
    game stage. */
@@ -35,11 +35,11 @@ extern int last_move[65];
 
 /* The number of moves available after a certain number
    of disks played. */
-extern int move_count[MAX_SEARCH_DEPTH];
+extern _Thread_local int move_count[MAX_SEARCH_DEPTH];
 
 /* The actual moves available after a certain number of
    disks played. */
-extern int move_list[MAX_SEARCH_DEPTH][64];
+extern _Thread_local int move_list[MAX_SEARCH_DEPTH][64];
 
 /* Directional flip masks for all board positions. */
 extern const int dir_mask[100];

--- a/src/search.c
+++ b/src/search.c
@@ -21,6 +21,7 @@
 #include "globals.h"
 #include "macros.h"
 #include "moves.h"
+#include "unflip.h"
 #include "search.h"
 #include "texts.h"
 
@@ -33,11 +34,13 @@ int root_eval;
 int force_return;
 int full_pv_depth;
 int full_pv[120];
-int list_inherited[61];
-int sorted_move_order[64][64];  /* 61*60 used */
-Board evals[61];
-CounterType nodes, total_nodes;
-CounterType evaluations, total_evaluations;
+_Thread_local int list_inherited[61];
+_Thread_local int sorted_move_order[64][64];  /* 61*60 used */
+_Thread_local Board evals[61];
+_Thread_local CounterType nodes;
+CounterType total_nodes;
+_Thread_local CounterType evaluations;
+CounterType total_evaluations;
 
 /* When no other information is available, JCW's endgame
    priority order is used also in the midgame. */
@@ -62,8 +65,8 @@ int position_list[100] = {
 /* Local variables */
 
 static int pondered_move = 0;
-static int negate_eval;
-static EvaluationType last_eval;
+static _Thread_local int negate_eval;
+static _Thread_local EvaluationType last_eval;
 
 
 
@@ -569,4 +572,17 @@ get_current_eval( void ) {
 void
 negate_current_eval( int negate ) {
   negate_eval = negate;
+}
+
+
+/*
+  INIT_SEARCH_THREAD
+  Initialize the thread-local search state.  Must be called once by
+  every thread that runs a search, before that thread searches
+  anything; the main thread gets it from game_init().
+*/
+
+void
+init_search_thread( void ) {
+  init_flip_stack();
 }

--- a/src/search.h
+++ b/src/search.h
@@ -67,23 +67,23 @@ extern int root_eval;
 extern int force_return;
 
 /* The number of positions evaluated during the current search. */
-extern CounterType evaluations;
+extern _Thread_local CounterType evaluations;
 
 /* The number of positions evaluated during the entire game. */
 extern CounterType total_evaluations;
 
 /* Holds the number of nodes searched during the current search. */
-extern CounterType nodes;
+extern _Thread_local CounterType nodes;
 
 /* Holds the total number of nodes searched during the entire game. */
 extern CounterType total_nodes;
 
 /* The last available evaluations for all possible moves at all
    possible game stages. */
-extern Board evals[61];
+extern _Thread_local Board evals[61];
 
 /* Move lists */
-extern int sorted_move_order[64][64];  /* 61*60 used */
+extern _Thread_local int sorted_move_order[64][64];  /* 61*60 used */
 
 /* The principal variation including passes */
 extern int full_pv_depth;
@@ -99,6 +99,9 @@ inherit_move_lists( int stage );
 
 void
 reorder_move_list( int stage );
+
+void
+init_search_thread( void );
 
 void
 setup_search( void );

--- a/src/stable.c
+++ b/src/stable.c
@@ -48,7 +48,7 @@
 
 /* All discs determined as stable last time COUNT_STABLE was called
    for the two colors */
-BitBoard last_black_stable, last_white_stable;
+_Thread_local BitBoard last_black_stable, last_white_stable;
 
 
 
@@ -68,12 +68,12 @@ static unsigned char black_stable[6561], white_stable[6561];
 static short base_conversion[256];
 
 /* The base-3 indices for the edges */
-static int edge_a1h1, edge_a8h8, edge_a1a8, edge_h1h8;
+static _Thread_local int edge_a1h1, edge_a8h8, edge_a1a8, edge_h1h8;
 
 
 /* Position list used in the complete stability search */
 
-MoveLink stab_move_list[100];
+_Thread_local MoveLink stab_move_list[100];
 
 #if 0
 INLINE static void

--- a/src/stable.h
+++ b/src/stable.h
@@ -26,7 +26,7 @@ extern "C" {
 
 
 
-extern BitBoard last_black_stable, last_white_stable;
+extern _Thread_local BitBoard last_black_stable, last_white_stable;
 
 
 

--- a/src/unflip.c
+++ b/src/unflip.c
@@ -17,8 +17,8 @@
 
 /* Global variables */
 
-int *global_flip_stack[2048];
-int **flip_stack = &(global_flip_stack[0]);
+_Thread_local int *global_flip_stack[2048];
+_Thread_local int **flip_stack;  /* per thread; see init_search_thread() */
 
 
 

--- a/src/unflip.h
+++ b/src/unflip.h
@@ -16,8 +16,8 @@
 
 
 
-extern int *global_flip_stack[2048];
-extern int **flip_stack;
+extern _Thread_local int *global_flip_stack[2048];
+extern _Thread_local int **flip_stack;
 
 
 


### PR DESCRIPTION
Every mutable object the search writes is now `_Thread_local`, so that
several threads can each run a search over their own board, hash key, flip
stack and move lists. Read-only tables (coefficients, hash keys,
precomputed masks) and the transposition table itself stay shared.

This is preparation for a parallel endgame search, split out so the
conversion can be reviewed on its own. Nothing here starts a thread; the
behaviour is unchanged apart from the cost noted below.

## What is covered

Everything reachable from `end_tree_search`, including the pieces that are
easy to overlook because they act as hidden return values rather than as
state the caller passes around:

* `bb_flips` in `bitbtest.c`, written by every `TestFlips` call
* `hash_update1` / `hash_update2` in `doflip.c`, written by `DoFlips`
* the scratch state in `stable.c` and `midgame.c` (`feas_index_list`,
  `allow_midgame_hash_probe` / `allow_midgame_hash_update`,
  `do_check_midgame_abort`, `apply_perturbation`, and the per-stage arrays)

Also adds `init_search_thread()`, which every thread must call before it
searches; `game_init()` calls it for the main thread. `flip_stack` loses its
static initializer as a result, so that call is now load-bearing rather than
a formality.

## Cost

Single-threaded this costs about 16% on FFO #48/#49. macOS resolves
thread-local addresses through `tlv_get_addr`, and `-ftls-model=local-exec`
does not help there.

The cost is spread over many variables rather than concentrated in one, so
removing it means grouping the state behind a single thread-local pointer.
Grouping the variables into one struct was tried and measured: it halves the
number of TLS resolution calls in `make_move` (15 to 7) with no runtime
change at all, which says the cost is not in address resolution. Actually
removing it means passing the search state as explicit function parameters,
a much larger refactor. Left for later, once the parallel search shows its
speedup.

## Verification

`make test` passes: the flip test and the FFO quick suite. Exact scores and
best moves are unchanged on FFO #45/#48/#49/#51.
