### PR TITLE
Add a worker thread pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ SRCS = \
 	probcut.c \
 	safemem.c \
 	search.c \
+	threads.c \
 	stable.c \
 	thordb.c \
 	timer.c \
@@ -65,6 +66,7 @@ PRACTICE_EXE = $(BINDIR)/practice
 ENDDEV_EXE   = $(BINDIR)/enddev
 TUNE8DBS_EXE = $(BINDIR)/tune8dbs
 FLIPTEST_EXE = $(BINDIR)/fliptest
+THREADTEST_EXE = $(BINDIR)/threadtest
 
 LIB          = $(BUILDDIR)/libzebra.a
 
@@ -76,9 +78,9 @@ DATA_LINKS   = $(BINDIR)/book.bin $(BINDIR)/coeffs2.bin
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-LDFLAGS		= -lm -lz
+LDFLAGS		= -lm -lz -pthread
 else
-LDFLAGS		= -static -lm -lz
+LDFLAGS		= -static -lm -lz -pthread
 endif
 #LDFLAGS	= -static -lm -lz -Wl,-Map,map.out
 
@@ -92,12 +94,13 @@ CXX		= g++
 # --- Flags ---
 
 DEFS =		-DINCLUDE_BOOKTOOL -DTEXT_BASED -DZLIB_STATIC
+THREAD_FLAGS =	-pthread
 
 WARNINGS =	-Wall -Wcast-align -Wwrite-strings -Wstrict-prototypes -Winline
 OPTS =		-O3 -fomit-frame-pointer -falign-functions=32
 #OPTS =		-O3 -fomit-frame-pointer -mtune=core2 -falign-functions=32
 
-CFLAGS =	$(OPTS) $(WARNINGS) $(DEFS) -I$(SRCDIR) -MMD -MP
+CFLAGS =	$(OPTS) $(WARNINGS) $(DEFS) $(THREAD_FLAGS) -I$(SRCDIR) -MMD -MP
 CXXFLAGS =	$(CFLAGS)
 
 
@@ -125,18 +128,23 @@ libzebra.a	: $(LIB)
 # FFO positions are solved in parallel; override the degree with
 # e.g. "make test FFO_JOBS=8" (default 4).
 
-test		: $(FLIPTEST_EXE) scrzebra
+test		: $(FLIPTEST_EXE) $(THREADTEST_EXE) scrzebra
 	$(FLIPTEST_EXE)
+	$(THREADTEST_EXE)
 	sh $(TESTDIR)/check_ffo.sh quick $(FFO_JOBS)
 
 # Solves ALL positions in tests/ffotest.scr and verifies the results.
 # WARNING: this takes a very long time (multiple hours).
-test-full	: $(FLIPTEST_EXE) scrzebra
+test-full	: $(FLIPTEST_EXE) $(THREADTEST_EXE) scrzebra
 	$(FLIPTEST_EXE)
+	$(THREADTEST_EXE)
 	sh $(TESTDIR)/check_ffo.sh full $(FFO_JOBS)
 
 $(FLIPTEST_EXE)	: $(TESTDIR)/fliptest.c $(LIB) | $(BINDIR)
 	$(CC) -o $@ $(CFLAGS) $(TESTDIR)/fliptest.c $(LIB) $(LDFLAGS)
+
+$(THREADTEST_EXE)	: $(TESTDIR)/threadtest.c $(LIB) | $(BINDIR)
+	$(CC) -o $@ $(CFLAGS) $(TESTDIR)/threadtest.c $(LIB) $(LDFLAGS)
 
 .PHONY		: all clean test test-full zebra scrzebra booktool practice enddev tune8dbs libzebra.a
 

--- a/src/threads.c
+++ b/src/threads.c
@@ -1,0 +1,208 @@
+/*
+   File:          threads.c
+
+   Created:       August 9, 2026
+
+   Contents:      A small fork-join worker pool for the parallel search.
+
+                  The pool is deliberately minimal: the caller hands in
+                  a job function and a job count, and every thread --
+                  the caller included -- claims jobs off a shared
+                  counter until they run out.  That keeps the work
+                  balanced without a queue, and it means a search can
+                  fall back to running everything on the calling thread
+                  simply by asking for one thread.
+*/
+
+
+
+#include <pthread.h>
+#include <stdlib.h>
+
+#include "constant.h"
+#include "search.h"
+#include "threads.h"
+
+
+
+#define MAX_THREADS               64
+
+
+
+typedef struct {
+  pthread_mutex_t lock;
+  pthread_cond_t work_ready;
+  pthread_cond_t work_done;
+  void (*job)( int index, void *context );
+  void *context;
+  int job_count;
+  int next_job;
+  int busy_count;      /* workers still inside the current batch */
+  int generation;      /* bumped once per batch, so wake-ups are unambiguous */
+  int shutting_down;
+} PoolState;
+
+
+
+/* Local variables */
+
+static PoolState pool;
+static pthread_t worker[MAX_THREADS];
+static int thread_count = 1;
+static int worker_count;   /* threads in worker[], i.e. thread_count - 1 */
+static int pool_created;
+
+
+
+/*
+  CLAIM_JOBS
+  Run jobs off the shared counter until the batch is exhausted.
+  Called with the lock held; releases it while a job runs.
+*/
+
+static void
+claim_jobs( int generation ) {
+  while ( TRUE ) {
+    int index;
+
+    if ( (pool.generation != generation) || (pool.next_job >= pool.job_count) )
+      return;
+    index = pool.next_job++;
+
+    pthread_mutex_unlock( &pool.lock );
+    pool.job( index, pool.context );
+    pthread_mutex_lock( &pool.lock );
+  }
+}
+
+
+/*
+  WORKER_MAIN
+  Wait for a batch, take part in it, and report back when it is done.
+*/
+
+static void *
+worker_main( void *arg ) {
+  int last_generation = 0;
+
+  (void) arg;
+  init_search_thread();
+
+  pthread_mutex_lock( &pool.lock );
+  while ( TRUE ) {
+    while ( !pool.shutting_down && (pool.generation == last_generation) )
+      pthread_cond_wait( &pool.work_ready, &pool.lock );
+    if ( pool.shutting_down )
+      break;
+    last_generation = pool.generation;
+
+    claim_jobs( last_generation );
+
+    if ( --pool.busy_count == 0 )
+      pthread_cond_signal( &pool.work_done );
+  }
+  pthread_mutex_unlock( &pool.lock );
+
+  return NULL;
+}
+
+
+
+void
+threads_init( int count ) {
+  int i;
+
+  if ( count < 1 )
+    count = 1;
+  if ( count > MAX_THREADS )
+    count = MAX_THREADS;
+  if ( pool_created && (count == thread_count) )
+    return;
+
+  threads_shutdown();
+
+  thread_count = count;
+  worker_count = count - 1;
+  if ( worker_count == 0 ) {
+    pool_created = TRUE;
+    return;
+  }
+
+  pthread_mutex_init( &pool.lock, NULL );
+  pthread_cond_init( &pool.work_ready, NULL );
+  pthread_cond_init( &pool.work_done, NULL );
+  pool.generation = 0;
+  pool.shutting_down = FALSE;
+  pool.busy_count = 0;
+
+  for ( i = 0; i < worker_count; i++ )
+    if ( pthread_create( &worker[i], NULL, worker_main, NULL ) != 0 ) {
+      /* Carry on with however many threads we did get */
+      worker_count = i;
+      thread_count = i + 1;
+      break;
+    }
+  pool_created = TRUE;
+}
+
+
+void
+threads_shutdown( void ) {
+  int i;
+
+  if ( !pool_created )
+    return;
+  if ( worker_count > 0 ) {
+    pthread_mutex_lock( &pool.lock );
+    pool.shutting_down = TRUE;
+    pthread_cond_broadcast( &pool.work_ready );
+    pthread_mutex_unlock( &pool.lock );
+
+    for ( i = 0; i < worker_count; i++ )
+      pthread_join( worker[i], NULL );
+
+    pthread_cond_destroy( &pool.work_done );
+    pthread_cond_destroy( &pool.work_ready );
+    pthread_mutex_destroy( &pool.lock );
+  }
+  worker_count = 0;
+  thread_count = 1;
+  pool_created = FALSE;
+}
+
+
+int
+threads_count( void ) {
+  return thread_count;
+}
+
+
+void
+threads_run( void (*job)( int index, void *context ), void *context,
+	     int job_count ) {
+  int i;
+
+  if ( job_count <= 0 )
+    return;
+
+  if ( worker_count == 0 ) {  /* Single-threaded: just run them here */
+    for ( i = 0; i < job_count; i++ )
+      job( i, context );
+    return;
+  }
+
+  pthread_mutex_lock( &pool.lock );
+  pool.job = job;
+  pool.context = context;
+  pool.job_count = job_count;
+  pool.next_job = 0;
+  pool.busy_count = worker_count;
+  pool.generation++;
+  pthread_cond_broadcast( &pool.work_ready );
+
+  /* The caller does not take part: it is in the middle of its own
+     search, and a job would overwrite the very state it is using. */
+  while ( pool.busy_count > 0 )
+    pthread_cond_wait( &pool.work_done, &pool.lock );
+  pthread_mutex_unlock( &pool.lock );
+}

--- a/src/threads.h
+++ b/src/threads.h
@@ -1,0 +1,72 @@
+/*
+   File:          threads.h
+
+   Created:       August 9, 2026
+
+   Contents:      A small fork-join worker pool for the parallel search.
+*/
+
+
+
+#ifndef THREADS_H
+#define THREADS_H
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+/*
+  THREADS_INIT
+  Prepare the pool for a total of COUNT search threads, the calling
+  thread included; COUNT == 1 means everything runs on the caller and
+  no threads are created.  Safe to call again with a different count.
+*/
+
+void
+threads_init( int count );
+
+
+/*
+  THREADS_SHUTDOWN
+  Stop and join the worker threads.
+*/
+
+void
+threads_shutdown( void );
+
+
+/*
+  THREADS_COUNT
+  The number of search threads, the calling thread included.
+*/
+
+int
+threads_count( void );
+
+
+/*
+  THREADS_RUN
+  Run JOB( index, context ) for each index in [0, JOB_COUNT) and return
+  once all of them have finished.  Jobs are claimed by whichever thread
+  is free, the calling thread among them, so a job must not assume
+  anything about which thread runs it or in what order.  Each worker
+  has had init_search_thread() called on it.
+*/
+
+void
+threads_run( void (*job)( int index, void *context ), void *context,
+	     int job_count );
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+
+#endif  /* THREADS_H */

--- a/src/zebra.c
+++ b/src/zebra.c
@@ -35,6 +35,7 @@
 #include "osfbook.h"
 #include "patterns.h"
 #include "search.h"
+#include "threads.h"
 #include "thordb.h"
 #include "timer.h"
 
@@ -163,6 +164,7 @@ main( int argc, char *argv[] ) {
   int repeat = 1;
 #endif
   int run_script;
+  int n_threads = 1;
   int script_optimal_line = DEFAULT_DISPLAY_LINE;
 #if SCRIPT_ONLY
   int komi;
@@ -211,6 +213,13 @@ main( int argc, char *argv[] ) {
 	continue;
       }
       hash_bits = atoi( argv[arg_index] );
+    }
+    else if ( !strcasecmp( argv[arg_index], "-n" ) ) {
+      if ( ++arg_index == argc ) {
+	help = TRUE;
+	continue;
+      }
+      n_threads = atoi( argv[arg_index] );
     }
 #if !SCRIPT_ONLY    
     else if ( !strcasecmp( argv[arg_index], "-l" ) ) {
@@ -474,6 +483,9 @@ main( int argc, char *argv[] ) {
     puts( "  -e <echo?>" );
     printf( "    Toggles screen output on/off (default %d).\n\n",
 	    DEFAULT_ECHO );
+    puts( "  -n <search threads>" );
+    printf( "    Number of threads used by the endgame search (default %d).\n\n",
+	    1 );
     puts( "  -h <bits in hash key>" );
     printf( "    Size of hash table is 2^{this value} (default %d).\n\n",
 	    DEFAULT_HASH_BITS );
@@ -613,6 +625,7 @@ main( int argc, char *argv[] ) {
   }
 
   global_setup( use_random, hash_bits );
+  threads_init( n_threads );
   init_thor_database();
 
   if ( use_book )
@@ -659,6 +672,8 @@ main( int argc, char *argv[] ) {
     }
   }
 #endif
+
+  threads_shutdown();
 
   global_terminate();
 

--- a/tests/threadtest.c
+++ b/tests/threadtest.c
@@ -1,0 +1,94 @@
+/*
+   File:          threadtest.c
+
+   Contents:      Sanity check for the fork-join worker pool.
+
+   Verifies that every job in a batch runs exactly once, that batches
+   can be issued back to back, that work is actually spread over more
+   than one thread, and that asking for a single thread still runs
+   everything.  A pool that silently drops or double-runs jobs would
+   corrupt a parallel search in ways that are painful to debug from the
+   search side, so it is worth pinning down here.
+*/
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "threads.h"
+
+#define JOB_COUNT   400
+
+static int ran[JOB_COUNT];
+static pthread_t runner[JOB_COUNT];
+
+static volatile unsigned int sink;
+
+static void
+count_job( int index, void *context ) {
+  unsigned int i, x = index;
+
+  (void) context;
+  /* Enough work that a batch cannot be swallowed whole by whichever
+     worker happens to wake up first -- otherwise the check below that
+     the work really is spread out would be a coin toss. */
+  for ( i = 0; i < 200000; i++ )
+    x = x * 1103515245u + 12345u;
+  sink = x;
+
+  ran[index]++;
+  runner[index] = pthread_self();
+}
+
+static int
+run_batch( const char *label, int threads, int expect_parallel ) {
+  int i, distinct = 0;
+  pthread_t seen[8];
+
+  memset( ran, 0, sizeof( ran ) );
+  memset( runner, 0, sizeof( runner ) );
+
+  threads_init( threads );
+  if ( threads_count() < 1 ) {
+    printf( "FAIL  %s: threads_count() = %d\n", label, threads_count() );
+    return 1;
+  }
+  threads_run( count_job, NULL, JOB_COUNT );
+
+  for ( i = 0; i < JOB_COUNT; i++ )
+    if ( ran[i] != 1 ) {
+      printf( "FAIL  %s: job %d ran %d times\n", label, i, ran[i] );
+      return 1;
+    }
+
+  for ( i = 0; i < JOB_COUNT; i++ ) {
+    int j, known = 0;
+    for ( j = 0; j < distinct; j++ )
+      if ( pthread_equal( seen[j], runner[i] ) )
+	known = 1;
+    if ( !known && (distinct < 8) )
+      seen[distinct++] = runner[i];
+  }
+
+  if ( expect_parallel && (distinct < 2) ) {
+    printf( "FAIL  %s: all %d jobs ran on one thread\n", label, JOB_COUNT );
+    return 1;
+  }
+  printf( "ok    %s: %d jobs, %d thread(s)\n", label, JOB_COUNT, distinct );
+  return 0;
+}
+
+int
+main( void ) {
+  int status = 0;
+
+  status |= run_batch( "single thread", 1, 0 );
+  status |= run_batch( "four threads", 4, 1 );
+  status |= run_batch( "four threads again", 4, 1 );
+  status |= run_batch( "back to single", 1, 0 );
+  threads_shutdown();
+
+  puts( status ? "threadtest: FAILED" : "threadtest: PASSED" );
+  return status ? EXIT_FAILURE : EXIT_SUCCESS;
+}


### PR DESCRIPTION
A minimal fork-join worker pool, split out so it can be reviewed without
the search changes that use it.

The caller hands in a job function and a count, and every thread -- the
caller included -- claims jobs off a shared counter until they run out. No
queue, no work stealing, and asking for one thread runs everything inline on
the caller, so the sequential path stays exactly as it was.

Each worker calls `init_search_thread()` once, so it starts with its own
flip stack and search state from #12.

Adds `-n <threads>` to `zebra` and `scrzebra` (default 1 for now).

Nothing calls the pool from the search yet, so results and timings are
unchanged.

## Why write this rather than use an existing one

A thread pool is a common thing to want, so the obvious question is why
there are 200 lines of it here. The short answer is that C has no
standard-library thread pool, and the nearest standard option costs us the
stock-Mac build.

**C11 `<threads.h>`** is primitives only -- `thrd_create`, `mtx_*`, `cnd_*`
-- with no pool of any kind. It is also optional, and it is not available
here:

```
$ cc -std=c11 -c t.c
t.c:1:10: fatal error: 'threads.h' file not found
```

with `__STDC_NO_THREADS__` defined. (glibc only grew it in 2.28 either way.)
**POSIX pthreads** is likewise primitives only; that is what this pool is
built on.

**OpenMP** is the nearest thing to a standard answer, and it maps onto what
we need almost exactly:

| here | OpenMP |
|---|---|
| `threads_run` | `#pragma omp parallel for schedule(dynamic)` |
| `threads_is_worker` | `omp_in_parallel()` |
| `threads_count` | `omp_get_max_threads()` |

The problem is availability. Apple's clang rejects the flag outright:

```
$ cc -fopenmp t.c
clang: error: unsupported option '-fopenmp'
```

Building with OpenMP on macOS means a Homebrew `libomp` plus
`-Xpreprocessor -fopenmp -L/opt/homebrew/opt/libomp/lib -lomp`. That trades
200 lines of pthreads for a build-time dependency that breaks `make` on a
stock Mac, which is the opposite of the direction this repository has been
going. It would also not remove the per-thread setup: OpenMP does not
promise thread identity across parallel regions, so `init_search_thread()`
would still need a thread-local "have I been initialised" guard -- roughly
what `worker_main` does now.

**GCD `dispatch_apply`** does work out of the box on macOS and is a good fit
for fork-join, but it is Apple-specific and needs blocks (`^`), so it would
mean maintaining a second path for everyone else.

So: keep it. The API is five functions, there is no queue and no work
stealing, and `-n 1` creates no threads at all and runs every job inline on
the caller -- which is what makes it easy to argue that the sequential
search is still bit-for-bit the old code. If this is ever worth dropping,
OpenMP is the migration to make, and it is mechanical.

## Testing

`tests/threadtest.c` is new, and `make test` runs it alongside the existing
flip test and FFO check. It checks that:

* every job in a batch runs exactly once, and none runs twice
* back-to-back batches work, including switching the thread count between
  them and going back down to one
* the work really does land on more than one thread

That last one is the reason each job does a fixed amount of real work rather
than returning immediately: with trivially short jobs one thread can drain
the whole counter before the others have started, and the test would be
asserting on scheduling luck.
