### PR TITLE
Parallel endgame search (YBWC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ AUTOP_OBJ    = $(OBJDIR)/autop.o
 
 TESTDIR  = tests
 
-# How the FFO test spreads its work: FFO_JOBS positions at a time, each
-# searching with FFO_THREADS threads (empty means scrzebra's own
-# default).  These are plain assignments, not ?=, so that a variable of
-# the same name left exported in someone's environment cannot quietly
-# change what the test does; "make test FFO_JOBS=8" still wins, because
-# command line assignments override the makefile.
-FFO_JOBS    = 4
+# Search threads the FFO test gives each position; empty means one per
+# processor.  Positions are solved one at a time -- the endgame search
+# is parallel itself, so running several at once only makes them fight
+# over the same cores.  This is a plain assignment, not ?=, so that a
+# variable of the same name left exported in someone's environment
+# cannot quietly change what the test does; "make test FFO_THREADS=4"
+# still wins, because command line assignments override the makefile.
 FFO_THREADS =
 
 ZEBRA_EXE    = $(BINDIR)/zebra
@@ -134,22 +134,21 @@ libzebra.a	: $(LIB)
 #  2. check_ffo.sh: solves a fast subset of the FFO endgame test suite
 #     and verifies the scores against the published answers
 #
-# Override the parallelism with e.g. "make test FFO_JOBS=8
-# FFO_THREADS=2"; see where those are set above.  The two multiply, so
-# keep FFO_JOBS x FFO_THREADS near the core count.
+# Override the search threads with e.g. "make test FFO_THREADS=4"; see
+# where that is set above.
 
 test		: $(FLIPTEST_EXE) $(THREADTEST_EXE) scrzebra
 	$(FLIPTEST_EXE)
 	$(THREADTEST_EXE)
-	sh $(TESTDIR)/check_ffo.sh quick "$(FFO_JOBS)" "$(FFO_THREADS)"
+	sh $(TESTDIR)/check_ffo.sh quick "$(FFO_THREADS)"
 
 # Solves ALL positions in tests/ffotest.scr and verifies the results.
-# Takes several minutes -- about 7 on an 8-core machine, most of which
-# is FFO #55 on its own.
+# Takes several minutes -- about 8.5 on an 8-core machine, half of
+# which is FFO #55 on its own.
 test-full	: $(FLIPTEST_EXE) $(THREADTEST_EXE) scrzebra
 	$(FLIPTEST_EXE)
 	$(THREADTEST_EXE)
-	sh $(TESTDIR)/check_ffo.sh full "$(FFO_JOBS)" "$(FFO_THREADS)"
+	sh $(TESTDIR)/check_ffo.sh full "$(FFO_THREADS)"
 
 $(FLIPTEST_EXE)	: $(TESTDIR)/fliptest.c $(LIB) | $(BINDIR)
 	$(CC) -o $@ $(CFLAGS) $(TESTDIR)/fliptest.c $(LIB) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,15 @@ AUTOP_OBJ    = $(OBJDIR)/autop.o
 
 TESTDIR  = tests
 
+# How the FFO test spreads its work: FFO_JOBS positions at a time, each
+# searching with FFO_THREADS threads (empty means scrzebra's own
+# default).  These are plain assignments, not ?=, so that a variable of
+# the same name left exported in someone's environment cannot quietly
+# change what the test does; "make test FFO_JOBS=8" still wins, because
+# command line assignments override the makefile.
+FFO_JOBS    = 4
+FFO_THREADS =
+
 ZEBRA_EXE    = $(BINDIR)/zebra
 SCRZEBRA_EXE = $(BINDIR)/scrzebra
 BOOKTOOL_EXE = $(BINDIR)/booktool
@@ -125,20 +134,21 @@ libzebra.a	: $(LIB)
 #  2. check_ffo.sh: solves a fast subset of the FFO endgame test suite
 #     and verifies the scores against the published answers
 #
-# FFO positions are solved in parallel; override the degree with
-# e.g. "make test FFO_JOBS=8" (default 4).
+# Override the parallelism with e.g. "make test FFO_JOBS=8
+# FFO_THREADS=2"; see where those are set above.  The two multiply, so
+# keep FFO_JOBS x FFO_THREADS near the core count.
 
 test		: $(FLIPTEST_EXE) $(THREADTEST_EXE) scrzebra
 	$(FLIPTEST_EXE)
 	$(THREADTEST_EXE)
-	sh $(TESTDIR)/check_ffo.sh quick $(FFO_JOBS)
+	sh $(TESTDIR)/check_ffo.sh quick "$(FFO_JOBS)" "$(FFO_THREADS)"
 
 # Solves ALL positions in tests/ffotest.scr and verifies the results.
 # WARNING: this takes a very long time (multiple hours).
 test-full	: $(FLIPTEST_EXE) $(THREADTEST_EXE) scrzebra
 	$(FLIPTEST_EXE)
 	$(THREADTEST_EXE)
-	sh $(TESTDIR)/check_ffo.sh full $(FFO_JOBS)
+	sh $(TESTDIR)/check_ffo.sh full "$(FFO_JOBS)" "$(FFO_THREADS)"
 
 $(FLIPTEST_EXE)	: $(TESTDIR)/fliptest.c $(LIB) | $(BINDIR)
 	$(CC) -o $@ $(CFLAGS) $(TESTDIR)/fliptest.c $(LIB) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,8 @@ test		: $(FLIPTEST_EXE) $(THREADTEST_EXE) scrzebra
 	sh $(TESTDIR)/check_ffo.sh quick "$(FFO_JOBS)" "$(FFO_THREADS)"
 
 # Solves ALL positions in tests/ffotest.scr and verifies the results.
-# WARNING: this takes a very long time (multiple hours).
+# Takes several minutes -- about 7 on an 8-core machine, most of which
+# is FFO #55 on its own.
 test-full	: $(FLIPTEST_EXE) $(THREADTEST_EXE) scrzebra
 	$(FLIPTEST_EXE)
 	$(THREADTEST_EXE)

--- a/README.md
+++ b/README.md
@@ -53,11 +53,9 @@ It takes about 5-10 seconds and runs two tests:
   suite (`tests/ffo-quick.scr`: positions #40-#44, #46, #47 and #59) with
   `scrzebra` and checks the exact scores and best moves against the
   published answers from http://radagast.se/othello/ffotest.html
-  Positions are solved in parallel (4 at a time by default) and each
-  position's search can use several threads: `make test FFO_JOBS=8
-  FFO_THREADS=2`, or `sh tests/check_ffo.sh quick 8 2`. The two
-  multiply, so keep their product near the core count. `FFO_THREADS`
-  defaults to whatever `scrzebra` itself defaults to.
+  Positions are solved one at a time, each search using one thread per
+  processor. Override that with `make test FFO_THREADS=4`, or
+  `sh tests/check_ffo.sh quick 4`.
 
 The full FFO suite (`tests/ffotest.scr`, positions #40-#59) can be solved
 and verified with:
@@ -66,17 +64,14 @@ and verified with:
 make test-full
 ```
 
-**Caveat: this takes several minutes** — about 7 on an 8-core arm64 Mac
-with the default `FFO_JOBS=4 FFO_THREADS=2`. Most positions solve in
-under 15 seconds; the tail is #55 at roughly 6.5 minutes on its own,
-then #54 and #57 at a little over 2 minutes each. For scale, the
-reference result on the author's page is 2h06m for the whole suite on a
-1.33 GHz Athlon.
+**Caveat: this takes several minutes** — about 8.5 on an 8-core arm64
+Mac. Most positions solve in under 10 seconds; the tail is #55 at
+roughly 3.5 minutes on its own, then #57 at 1.5 minutes and #54 at just
+over 1. For scale, the reference result on the author's page is 2h06m
+for the whole suite on a 1.33 GHz Athlon.
 
-Positions run in parallel (default 4, e.g. `make test-full FFO_JOBS=8`
-to change it), each position's result and elapsed time is printed as
-soon as it is solved, and the raw results are collected in
-`build/ffo-full.out`.
+Each position's result and elapsed time is printed as soon as it is
+solved, and the raw results are collected in `build/ffo-full.out`.
 
 ## Web sites
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,17 @@ and verified with:
 make test-full
 ```
 
-**Caveat: this takes a very long time — expect multiple hours.** The
-reference result on the author's page is 2h06m for the whole suite (on a
-1.33 GHz Athlon); modern machines are faster but the hardest positions
-(#53-#58) still take from many minutes up to hours each. Positions run
-in parallel (default 4, e.g. `make test-full FFO_JOBS=8` to change it),
-each position's result and elapsed time is printed as soon as it is
-solved, and the raw results are collected in `build/ffo-full.out`.
+**Caveat: this takes several minutes** — about 7 on an 8-core arm64 Mac
+with the default `FFO_JOBS=4 FFO_THREADS=2`. Most positions solve in
+under 15 seconds; the tail is #55 at roughly 6.5 minutes on its own,
+then #54 and #57 at a little over 2 minutes each. For scale, the
+reference result on the author's page is 2h06m for the whole suite on a
+1.33 GHz Athlon.
+
+Positions run in parallel (default 4, e.g. `make test-full FFO_JOBS=8`
+to change it), each position's result and elapsed time is printed as
+soon as it is solved, and the raw results are collected in
+`build/ffo-full.out`.
 
 ## Web sites
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ git checkout original
 
 ## Parallel endgame search
 
-`zebra` and `scrzebra` take `-n <threads>` (default 1) to search the
+`zebra` and `scrzebra` take `-n <threads>` (default 2) to search the
 endgame on several threads. Once a node has searched its first move, the
 remaining moves are handed to a worker pool with a null window; the ones
 proved not to beat alpha are then skipped by the sequential search.
+Pass `-n 1` for a purely sequential search.
 
 Exact scores and best moves do not depend on the thread count. The tail
 of the principal variation can, because the transposition table is
@@ -52,8 +53,11 @@ It takes about 5-10 seconds and runs two tests:
   suite (`tests/ffo-quick.scr`: positions #40-#44, #46, #47 and #59) with
   `scrzebra` and checks the exact scores and best moves against the
   published answers from http://radagast.se/othello/ffotest.html
-  Positions are solved in parallel (4 at a time by default); use
-  `make test FFO_JOBS=8` or `sh tests/check_ffo.sh quick 8` to change it.
+  Positions are solved in parallel (4 at a time by default) and each
+  position's search can use several threads: `make test FFO_JOBS=8
+  FFO_THREADS=2`, or `sh tests/check_ffo.sh quick 8 2`. The two
+  multiply, so keep their product near the core count. `FFO_THREADS`
+  defaults to whatever `scrzebra` itself defaults to.
 
 The full FFO suite (`tests/ffotest.scr`, positions #40-#59) can be solved
 and verified with:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ get the source from the `original` tag:
 git checkout original
 ```
 
+## Parallel endgame search
+
+`zebra` and `scrzebra` take `-n <threads>` (default 1) to search the
+endgame on several threads. Once a node has searched its first move, the
+remaining moves are handed to a worker pool with a null window; the ones
+proved not to beat alpha are then skipped by the sequential search.
+
+Exact scores and best moves do not depend on the thread count. The tail
+of the principal variation can, because the transposition table is
+shared and gets filled in a different order.
+
+Measured on an 8-core machine:
+
+| Position | 1 thread | 8 threads |
+|----------|---------:|----------:|
+| FFO #45  |   11.9 s |     3.3 s |
+| FFO #48  |    7.0 s |     2.3 s |
+| FFO #49  |    9.6 s |     3.6 s |
+| FFO #51  |   10.7 s |     4.0 s |
+
 ## Testing
 
 Run the test suite with:

--- a/src/end.c
+++ b/src/end.c
@@ -1403,6 +1403,12 @@ typedef struct {
 } SiblingBatch;
 
 
+/* Set while a thread is running a job, so that a node reached from
+   inside a job does not try to start a batch of its own -- the pool is
+   already busy with the batch this job belongs to. */
+static _Thread_local int inside_job;
+
+
 static void
 search_sibling( int index, void *context ) {
   SiblingBatch *batch = (SiblingBatch *) context;
@@ -1412,11 +1418,13 @@ search_sibling( int index, void *context ) {
   int score;
   int **saved_flip_stack = flip_stack;
 
+  inside_job++;
   search_state_load( &batch->root );
   set_bitboards( board, batch->side_to_move, &my_bits, &opp_bits );
 
   if ( make_move( batch->side_to_move, move, TRUE ) == 0 ) {
     flip_stack = saved_flip_stack;   /* cannot happen; be safe anyway */
+    inside_job--;
     return;
   }
   (void) TestFlips_wrapper( move, my_bits, opp_bits );
@@ -1433,6 +1441,7 @@ search_sibling( int index, void *context ) {
   /* The move is never unmade, so put the flip stack back by hand;
      leaving it advanced would overflow it after a few jobs. */
   flip_stack = saved_flip_stack;
+  inside_job--;
 
   if ( !is_panic_abort() && !force_return ) {
     batch->score[index] = score;
@@ -1733,7 +1742,7 @@ end_tree_search( int level,
      worth a batch, and only the search thread splits (see
      threads_is_worker). */
   can_split = (remains >= PARALLEL_SPLIT_DEPTH) && (threads_count() > 1) &&
-    !threads_is_worker();
+    !threads_is_worker() && !inside_job;
   if ( can_split )
     for ( i = 0; i < 100; i++ )
       proven[i] = FALSE;

--- a/src/end.c
+++ b/src/end.c
@@ -39,6 +39,7 @@
 #include "probcut.h"
 #include "search.h"
 #include "stable.h"
+#include "threads.h"
 #include "texts.h"
 #include "timer.h"
 #include "unflip.h"
@@ -1362,6 +1363,130 @@ update_best_list( int *best_list, int move, int best_list_index,
 
 
 
+
+
+static int
+end_tree_search( int level, int max_depth, BitBoard my_bits,
+		 BitBoard opp_bits, int side_to_move, int alpha, int beta,
+		 int selectivity, int *selective_cutoff, int void_legal );
+
+
+/*
+  PARALLEL ROOT SIBLINGS
+
+  Young-brothers-wait: the first root move is searched on its own, and
+  only once it has produced a bound are the remaining moves handed out
+  to the pool.  Each of them gets a null window, which is what the
+  sequential search would have given them anyway, and the vast majority
+  fail low -- those the sequential loop can then skip outright.  A move
+  that fails high is left alone here and re-searched in order by the
+  sequential loop, so the score and the principal variation are still
+  produced by exactly the same code as before.
+*/
+
+#define MAX_ROOT_MOVES               64
+
+typedef struct {
+  SearchState root;
+  int max_depth;
+  int side_to_move;
+  int alpha;                        /* null window is (alpha, alpha + 1) */
+  int selectivity;
+  int move[MAX_ROOT_MOVES];
+  int score[MAX_ROOT_MOVES];
+  int valid[MAX_ROOT_MOVES];
+} SiblingBatch;
+
+
+static void
+search_sibling( int index, void *context ) {
+  SiblingBatch *batch = (SiblingBatch *) context;
+  BitBoard my_bits, opp_bits, new_my_bits, new_opp_bits;
+  int move = batch->move[index];
+  int child_selective_cutoff = FALSE;
+  int score;
+  int **saved_flip_stack = flip_stack;
+
+  search_state_load( &batch->root );
+  set_bitboards( board, batch->side_to_move, &my_bits, &opp_bits );
+
+  if ( make_move( batch->side_to_move, move, TRUE ) == 0 ) {
+    flip_stack = saved_flip_stack;   /* cannot happen; be safe anyway */
+    return;
+  }
+  (void) TestFlips_wrapper( move, my_bits, opp_bits );
+  new_my_bits = bb_flips;
+  FULL_ANDNOT( new_opp_bits, opp_bits, bb_flips );
+
+  score = -end_tree_search( 1, batch->max_depth,
+			    new_opp_bits, new_my_bits,
+			    OPP( batch->side_to_move ),
+			    -(batch->alpha + 1), -batch->alpha,
+			    batch->selectivity, &child_selective_cutoff,
+			    TRUE );
+
+  /* The move is never unmade, so put the flip stack back by hand;
+     leaving it advanced would overflow it after a few jobs. */
+  flip_stack = saved_flip_stack;
+
+  if ( !is_panic_abort() && !force_return ) {
+    batch->score[index] = score;
+    batch->valid[index] = TRUE;
+  }
+}
+
+
+/*
+  DISPATCH_ROOT_SIBLINGS
+  Search every legal root move except SEARCHED_MOVE in parallel with a
+  null window around ALPHA.  Fills PROVEN[sq] with a score for each move
+  that was proved not to beat ALPHA.
+*/
+
+static void
+dispatch_root_siblings( BitBoard my_bits, BitBoard opp_bits,
+			int side_to_move, int max_depth, int alpha,
+			int selectivity, int searched_move,
+			int *proven, int *proven_score ) {
+  static SiblingBatch batch;     /* only the root thread gets here */
+  int i, j, sq, count = 0;
+
+  for ( i = 1; i <= 8; i++ )
+    for ( j = 1; j <= 8; j++ ) {
+      sq = 10 * i + j;
+      if ( (sq == searched_move) || (board[sq] != EMPTY) )
+	continue;
+      if ( TestFlips_wrapper( sq, my_bits, opp_bits ) == 0 )
+	continue;
+      if ( count < MAX_ROOT_MOVES ) {
+	batch.move[count] = sq;
+	batch.score[count] = 0;
+	batch.valid[count] = FALSE;
+	count++;
+      }
+    }
+  if ( count == 0 )
+    return;
+
+  batch.max_depth = max_depth;
+  batch.side_to_move = side_to_move;
+  batch.alpha = alpha;
+  batch.selectivity = selectivity;
+  search_state_save( &batch.root );
+
+  threads_run( search_sibling, &batch, count );
+
+  /* The calling thread takes part in the batch, so put its own state
+     back the way the sequential search left it. */
+  search_state_load( &batch.root );
+
+  for ( i = 0; i < count; i++ )
+    if ( batch.valid[i] && (batch.score[i] <= alpha) ) {
+      proven[batch.move[i]] = TRUE;
+      proven_score[batch.move[i]] = batch.score[i];
+    }
+}
+
 /*
   END_TREE_SEARCH
   Plain nega-scout with fastest-first move ordering.
@@ -1398,6 +1523,8 @@ end_tree_search( int level,
   int threshold;
   int best_list_index, best_list_length;
   int best_list[4];
+  int proven[100], proven_score[100];
+  int siblings_dispatched = FALSE;
   HashEntry entry, mid_entry;
 #if CHECK_HASH_CODES
   unsigned int h1, h2;
@@ -1588,6 +1715,9 @@ end_tree_search( int level,
 
   exp_depth = remains;
   first = TRUE;
+  if ( level == 0 )
+    for ( i = 0; i < 100; i++ )
+      proven[i] = FALSE;
   best = -INFINITE_EVAL;
   pre_search_done = FALSE;
   curr_alpha = alpha;
@@ -1767,11 +1897,14 @@ end_tree_search( int level,
     }
     else {
       curr_alpha = MAX( best, curr_alpha );
-      curr_val =
-	-end_tree_search( level + 1, level + exp_depth,
-			  new_opp_bits, new_my_bits, OPP( side_to_move ),
-			  -(curr_alpha + 1), -curr_alpha,
-			  selectivity, &child_selective_cutoff, TRUE );
+      if ( (level == 0) && proven[move] && (proven_score[move] <= curr_alpha) )
+	curr_val = proven_score[move];   /* already proved not to beat alpha */
+      else
+	curr_val =
+	  -end_tree_search( level + 1, level + exp_depth,
+			    new_opp_bits, new_my_bits, OPP( side_to_move ),
+			    -(curr_alpha + 1), -curr_alpha,
+			    selectivity, &child_selective_cutoff, TRUE );
       if ( (curr_val > curr_alpha) && (curr_val < beta) ) {
 	if ( selectivity > 0 )
 	  curr_val =
@@ -1848,6 +1981,14 @@ end_tree_search( int level,
     if ( (best_list_index >= best_list_length) && !update_pv &&
 	 (best_list_length < 4) )
       best_list[best_list_length++] = move;
+
+    if ( (level == 0) && first && !siblings_dispatched &&
+	 (threads_count() > 1) && !is_panic_abort() && !force_return ) {
+      siblings_dispatched = TRUE;
+      dispatch_root_siblings( my_bits, opp_bits, side_to_move,
+			      level + exp_depth, best, selectivity,
+			      move, proven, proven_score );
+    }
 
     first = FALSE;
   }

--- a/src/end.c
+++ b/src/end.c
@@ -1386,14 +1386,19 @@ end_tree_search( int level, int max_depth, BitBoard my_bits,
 
 #define MAX_ROOT_MOVES               64
 
+/* Remaining depth at or above which a node is worth splitting */
+#define PARALLEL_SPLIT_DEPTH         14
+
 typedef struct {
   SearchState root;
+  int level;
   int max_depth;
   int side_to_move;
   int alpha;                        /* null window is (alpha, alpha + 1) */
   int selectivity;
   int move[MAX_ROOT_MOVES];
   int score[MAX_ROOT_MOVES];
+  int cutoff[MAX_ROOT_MOVES];
   int valid[MAX_ROOT_MOVES];
 } SiblingBatch;
 
@@ -1418,7 +1423,7 @@ search_sibling( int index, void *context ) {
   new_my_bits = bb_flips;
   FULL_ANDNOT( new_opp_bits, opp_bits, bb_flips );
 
-  score = -end_tree_search( 1, batch->max_depth,
+  score = -end_tree_search( batch->level + 1, batch->max_depth,
 			    new_opp_bits, new_my_bits,
 			    OPP( batch->side_to_move ),
 			    -(batch->alpha + 1), -batch->alpha,
@@ -1431,24 +1436,29 @@ search_sibling( int index, void *context ) {
 
   if ( !is_panic_abort() && !force_return ) {
     batch->score[index] = score;
+    batch->cutoff[index] = child_selective_cutoff;
     batch->valid[index] = TRUE;
   }
 }
 
 
 /*
-  DISPATCH_ROOT_SIBLINGS
-  Search every legal root move except SEARCHED_MOVE in parallel with a
-  null window around ALPHA.  Fills PROVEN[sq] with a score for each move
-  that was proved not to beat ALPHA.
+  DISPATCH_SIBLINGS
+  Search every legal move of this node except SEARCHED_MOVE in parallel
+  with a null window around ALPHA.  Fills PROVEN[sq] with a score for
+  each move that was proved not to beat ALPHA, which the sequential
+  loop can then take instead of searching the move itself.
 */
 
 static void
-dispatch_root_siblings( BitBoard my_bits, BitBoard opp_bits,
-			int side_to_move, int max_depth, int alpha,
-			int selectivity, int searched_move,
-			int *proven, int *proven_score ) {
-  static SiblingBatch batch;     /* only the root thread gets here */
+dispatch_siblings( BitBoard my_bits, BitBoard opp_bits,
+		   int side_to_move, int level, int max_depth, int alpha,
+		   int selectivity, int searched_move,
+		   int *proven, int *proven_score, int *proven_cutoff ) {
+  /* Only the search thread splits, and it is inside one split at a
+     time -- an inner split finishes before its parent starts one --
+     so a single batch is enough and it need not be on the stack. */
+  static SiblingBatch batch;
   int i, j, sq, count = 0;
 
   for ( i = 1; i <= 8; i++ )
@@ -1461,6 +1471,7 @@ dispatch_root_siblings( BitBoard my_bits, BitBoard opp_bits,
       if ( count < MAX_ROOT_MOVES ) {
 	batch.move[count] = sq;
 	batch.score[count] = 0;
+	batch.cutoff[count] = FALSE;
 	batch.valid[count] = FALSE;
 	count++;
       }
@@ -1468,6 +1479,7 @@ dispatch_root_siblings( BitBoard my_bits, BitBoard opp_bits,
   if ( count == 0 )
     return;
 
+  batch.level = level;
   batch.max_depth = max_depth;
   batch.side_to_move = side_to_move;
   batch.alpha = alpha;
@@ -1484,6 +1496,7 @@ dispatch_root_siblings( BitBoard my_bits, BitBoard opp_bits,
     if ( batch.valid[i] && (batch.score[i] <= alpha) ) {
       proven[batch.move[i]] = TRUE;
       proven_score[batch.move[i]] = batch.score[i];
+      proven_cutoff[batch.move[i]] = batch.cutoff[i];
     }
 }
 
@@ -1523,8 +1536,9 @@ end_tree_search( int level,
   int threshold;
   int best_list_index, best_list_length;
   int best_list[4];
-  int proven[100], proven_score[100];
+  int proven[100], proven_score[100], proven_cutoff[100];
   int siblings_dispatched = FALSE;
+  int can_split;
   HashEntry entry, mid_entry;
 #if CHECK_HASH_CODES
   unsigned int h1, h2;
@@ -1715,7 +1729,12 @@ end_tree_search( int level,
 
   exp_depth = remains;
   first = TRUE;
-  if ( level == 0 )
+  /* Split only near the top of the tree: further down a subtree is not
+     worth a batch, and only the search thread splits (see
+     threads_is_worker). */
+  can_split = (remains >= PARALLEL_SPLIT_DEPTH) && (threads_count() > 1) &&
+    !threads_is_worker();
+  if ( can_split )
     for ( i = 0; i < 100; i++ )
       proven[i] = FALSE;
   best = -INFINITE_EVAL;
@@ -1897,14 +1916,19 @@ end_tree_search( int level,
     }
     else {
       curr_alpha = MAX( best, curr_alpha );
-      if ( (level == 0) && proven[move] && (proven_score[move] <= curr_alpha) )
-	curr_val = proven_score[move];   /* already proved not to beat alpha */
+      if ( can_split && proven[move] && (proven_score[move] <= curr_alpha) ) {
+	/* Already proved not to beat alpha; the child's selectivity flag
+	   has to come along, the caller stores it in the hash entry. */
+	curr_val = proven_score[move];
+	child_selective_cutoff = proven_cutoff[move];
+      }
       else
 	curr_val =
 	  -end_tree_search( level + 1, level + exp_depth,
 			    new_opp_bits, new_my_bits, OPP( side_to_move ),
 			    -(curr_alpha + 1), -curr_alpha,
 			    selectivity, &child_selective_cutoff, TRUE );
+
       if ( (curr_val > curr_alpha) && (curr_val < beta) ) {
 	if ( selectivity > 0 )
 	  curr_val =
@@ -1982,12 +2006,12 @@ end_tree_search( int level,
 	 (best_list_length < 4) )
       best_list[best_list_length++] = move;
 
-    if ( (level == 0) && first && !siblings_dispatched &&
-	 (threads_count() > 1) && !is_panic_abort() && !force_return ) {
+    if ( can_split && first && !siblings_dispatched &&
+	 !is_panic_abort() && !force_return ) {
       siblings_dispatched = TRUE;
-      dispatch_root_siblings( my_bits, opp_bits, side_to_move,
-			      level + exp_depth, best, selectivity,
-			      move, proven, proven_score );
+      dispatch_siblings( my_bits, opp_bits, side_to_move, level,
+			 level + exp_depth, best, selectivity,
+			 move, proven, proven_score, proven_cutoff );
     }
 
     first = FALSE;

--- a/src/search.c
+++ b/src/search.c
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "constant.h"
 #include "counter.h"
@@ -585,4 +586,36 @@ negate_current_eval( int negate ) {
 void
 init_search_thread( void ) {
   init_flip_stack();
+}
+
+
+/*
+  SEARCH_STATE_SAVE
+*/
+
+void
+search_state_save( SearchState *state ) {
+  memcpy( state->board, board, sizeof( Board ) );
+  memcpy( state->piece_count, piece_count, sizeof( state->piece_count ) );
+  memcpy( state->sorted_move_order, sorted_move_order,
+	  sizeof( state->sorted_move_order ) );
+  state->hash1 = hash1;
+  state->hash2 = hash2;
+  state->disks_played = disks_played;
+}
+
+
+/*
+  SEARCH_STATE_LOAD
+*/
+
+void
+search_state_load( const SearchState *state ) {
+  memcpy( board, state->board, sizeof( Board ) );
+  memcpy( piece_count, state->piece_count, sizeof( state->piece_count ) );
+  memcpy( sorted_move_order, state->sorted_move_order,
+	  sizeof( state->sorted_move_order ) );
+  hash1 = state->hash1;
+  hash2 = state->hash2;
+  disks_played = state->disks_played;
 }

--- a/src/search.h
+++ b/src/search.h
@@ -100,8 +100,36 @@ inherit_move_lists( int stage );
 void
 reorder_move_list( int stage );
 
+/* A copy of the per-thread search state, enough for another thread to
+   pick up the search from the same position.  Only the state that is
+   read before it is written needs to travel: everything indexed by
+   disks_played (move lists, flip counts, stored hash keys) is written
+   on the way down before it is read on the way back up. */
+
+typedef struct {
+  Board board;
+  int piece_count[3][MAX_SEARCH_DEPTH];
+  int sorted_move_order[64][64];
+  unsigned int hash1, hash2;
+  int disks_played;
+} SearchState;
+
+
 void
 init_search_thread( void );
+
+
+/*
+  SEARCH_STATE_SAVE / SEARCH_STATE_LOAD
+  Copy the calling thread's search state out of / into the thread-local
+  globals, so that a worker can search from where another thread was.
+*/
+
+void
+search_state_save( SearchState *state );
+
+void
+search_state_load( const SearchState *state );
 
 void
 setup_search( void );

--- a/src/threads.c
+++ b/src/threads.c
@@ -204,13 +204,18 @@ threads_run( void (*job)( int index, void *context ), void *context,
   pool.context = context;
   pool.job_count = job_count;
   pool.next_job = 0;
-  pool.busy_count = worker_count;
+  pool.busy_count = worker_count + 1;   /* the workers plus the caller */
   pool.generation++;
   pthread_cond_broadcast( &pool.work_ready );
 
-  /* The caller does not take part: it is in the middle of its own
-     search, and a job would overwrite the very state it is using. */
-  while ( pool.busy_count > 0 )
-    pthread_cond_wait( &pool.work_done, &pool.lock );
+  /* The caller helps rather than idling.  It is up to the caller to put
+     its own search state back afterwards, since a job overwrites the
+     state it was using, and not to start a nested batch from inside a
+     job -- the pool is already busy with this one. */
+  claim_jobs( pool.generation );
+
+  if ( --pool.busy_count > 0 )
+    while ( pool.busy_count > 0 )
+      pthread_cond_wait( &pool.work_done, &pool.lock );
   pthread_mutex_unlock( &pool.lock );
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -51,6 +51,7 @@ static pthread_t worker[MAX_THREADS];
 static int thread_count = 1;
 static int worker_count;   /* threads in worker[], i.e. thread_count - 1 */
 static int pool_created;
+static _Thread_local int is_worker;
 
 
 
@@ -86,6 +87,7 @@ worker_main( void *arg ) {
   int last_generation = 0;
 
   (void) arg;
+  is_worker = TRUE;
   init_search_thread();
 
   pthread_mutex_lock( &pool.lock );
@@ -174,6 +176,12 @@ threads_shutdown( void ) {
 int
 threads_count( void ) {
   return thread_count;
+}
+
+
+int
+threads_is_worker( void ) {
+  return is_worker;
 }
 
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -62,11 +62,13 @@ threads_is_worker( void );
 /*
   THREADS_RUN
   Run JOB( index, context ) for each index in [0, JOB_COUNT) and return
-  once all of them have finished.  Jobs are claimed by whichever worker
+  once all of them have finished.  Jobs are claimed by whichever thread
   is free, so a job must not assume anything about which thread runs it
-  or in what order.  The calling thread only waits -- it is typically
-  suspended in the middle of its own search, which a job would trample.
-  Each worker has had init_search_thread() called on it.
+  or in what order.  The calling thread takes part rather than idling,
+  which means a job runs on it too, on top of the search it is suspended
+  in the middle of; it is the caller's job to keep the two from
+  trampling each other.  Each worker has had init_search_thread()
+  called on it.
 */
 
 void

--- a/src/threads.h
+++ b/src/threads.h
@@ -49,12 +49,24 @@ threads_count( void );
 
 
 /*
+  THREADS_IS_WORKER
+  TRUE when called on one of the pool's worker threads.  A worker must
+  not start a batch of its own: the pool has no spare threads to run it
+  and would wait for itself.
+*/
+
+int
+threads_is_worker( void );
+
+
+/*
   THREADS_RUN
   Run JOB( index, context ) for each index in [0, JOB_COUNT) and return
-  once all of them have finished.  Jobs are claimed by whichever thread
-  is free, the calling thread among them, so a job must not assume
-  anything about which thread runs it or in what order.  Each worker
-  has had init_search_thread() called on it.
+  once all of them have finished.  Jobs are claimed by whichever worker
+  is free, so a job must not assume anything about which thread runs it
+  or in what order.  The calling thread only waits -- it is typically
+  suspended in the middle of its own search, which a job would trample.
+  Each worker has had init_search_thread() called on it.
 */
 
 void

--- a/src/zebra.c
+++ b/src/zebra.c
@@ -63,6 +63,8 @@
 #define DEFAULT_USE_BOOK          TRUE
 #endif
 
+#define DEFAULT_THREADS           2
+
 /* Get rid of some ugly warnings by disallowing usage of the
    macro version of tolower (not time-critical anyway). */
 #ifdef tolower
@@ -164,7 +166,7 @@ main( int argc, char *argv[] ) {
   int repeat = 1;
 #endif
   int run_script;
-  int n_threads = 1;
+  int n_threads = DEFAULT_THREADS;
   int script_optimal_line = DEFAULT_DISPLAY_LINE;
 #if SCRIPT_ONLY
   int komi;
@@ -485,7 +487,7 @@ main( int argc, char *argv[] ) {
 	    DEFAULT_ECHO );
     puts( "  -n <search threads>" );
     printf( "    Number of threads used by the endgame search (default %d).\n\n",
-	    1 );
+	    DEFAULT_THREADS );
     puts( "  -h <bits in hash key>" );
     printf( "    Size of hash table is 2^{this value} (default %d).\n\n",
 	    DEFAULT_HASH_BITS );
@@ -506,7 +508,7 @@ main( int argc, char *argv[] ) {
     puts( "" );
 #else    
     puts( "Usage:" );
-    puts( "  zebra [-b -e -g -h -l -p -t -time -w -learn -slack -dev -log" );
+    puts( "  zebra [-b -e -g -h -l -n -p -t -time -w -learn -slack -dev -log" );
     puts( "         -keepdraw -draw2black -draw2white -draw2none" );
     puts( "         -private -public -test -seq -thor -script -analyze ?" );
     puts( "         -repeat -seqfile]" );
@@ -525,6 +527,9 @@ main( int argc, char *argv[] ) {
     puts( "" );
     puts( "  -g <game file>" );
     puts( "" );
+    puts( "  -n <search threads>" );
+    printf( "    Number of threads used by the endgame search (default %d).\n\n",
+	    DEFAULT_THREADS );
     puts( "  -h <bits in hash key>" );
     printf( "    Size of hash table is 2^{this value} (default %d).\n",
 	    DEFAULT_HASH_BITS );

--- a/tests/check_ffo.sh
+++ b/tests/check_ffo.sh
@@ -4,11 +4,18 @@
 # published answers from http://radagast.se/othello/ffotest.html
 #
 # Usage (from the repository root, typically via make):
-#   sh tests/check_ffo.sh [quick|full] [jobs]
+#   sh tests/check_ffo.sh [quick|full] [jobs] [threads]
 #
-#   quick : subset of fast positions (~5 seconds), the default
-#   full  : all of tests/ffotest.scr -- takes a VERY long time
-#   jobs  : how many positions to solve in parallel (default 4)
+# make passes these through as FFO_JOBS and FFO_THREADS.
+#
+#   quick   : subset of fast positions (~5 seconds), the default
+#   full    : all of tests/ffotest.scr -- takes a VERY long time
+#   jobs    : how many positions to solve in parallel (default 4)
+#   threads : search threads per position, i.e. scrzebra's -n
+#             (default: whatever scrzebra itself defaults to)
+#
+# Note that the two multiply: jobs x threads processes' worth of work
+# can be running at once.
 #
 # Positions are solved in separate scrzebra processes (they share only
 # the read-only coeffs2.bin), so they can run concurrently.  A result
@@ -30,12 +37,12 @@ fi
 
 # ----- worker: solve and check one position ---------------------------
 # Invoked (via xargs) as: check_ffo.sh __worker <idx> <ffo#> <black> <white> <moves>
-# Inherits OUT from the parent through the environment.
+# Inherits OUT and FFO_NFLAG from the parent through the environment.
 if [ "$1" = "__worker" ]; then
   i=$2; ffo=$3; eblack=$4; ewhite=$5; emoves=$6
 
   pos_start=$(now)
-  ( cd build/bin && ./scrzebra -line 1 -script ffo-pos$i.scr ffo-pos$i.out ) >/dev/null
+  ( cd build/bin && ./scrzebra $FFO_NFLAG -line 1 -script ffo-pos$i.scr ffo-pos$i.out ) >/dev/null
   pos_end=$(now)
   elapsed=$(awk "BEGIN { printf \"%.1f\", $pos_end - $pos_start }")
 
@@ -69,6 +76,7 @@ fi
 
 MODE=${1:-quick}
 JOBS=${2:-4}
+THREADS=$3
 BIN=build/bin/scrzebra
 
 case "$JOBS" in
@@ -76,6 +84,18 @@ case "$JOBS" in
     echo "check_ffo: jobs must be a positive integer" >&2
     exit 1 ;;
 esac
+
+if [ -n "$THREADS" ]; then
+  case "$THREADS" in
+    *[!0-9]*|0)
+      echo "check_ffo: threads must be a positive integer" >&2
+      exit 1 ;;
+  esac
+  FFO_NFLAG="-n $THREADS"
+else
+  FFO_NFLAG=""
+fi
+export FFO_NFLAG
 
 if [ "$MODE" = "full" ]; then
   SCRIPT=tests/ffotest.scr
@@ -125,7 +145,11 @@ fi
 if [ "$MODE" = "full" ]; then
   echo "check_ffo: solving the full FFO test suite; this takes a LONG time."
 fi
-echo "check_ffo: running $JOBS position(s) in parallel"
+if [ -n "$THREADS" ]; then
+  echo "check_ffo: running $JOBS position(s) in parallel, $THREADS thread(s) each"
+else
+  echo "check_ffo: running $JOBS position(s) in parallel"
+fi
 
 # One position per line, comments stripped
 POSFILE=$OUT.positions

--- a/tests/check_ffo.sh
+++ b/tests/check_ffo.sh
@@ -4,23 +4,20 @@
 # published answers from http://radagast.se/othello/ffotest.html
 #
 # Usage (from the repository root, typically via make):
-#   sh tests/check_ffo.sh [quick|full] [jobs] [threads]
+#   sh tests/check_ffo.sh [quick|full] [threads]
 #
-# make passes these through as FFO_JOBS and FFO_THREADS.
+# make passes the thread count through as FFO_THREADS.
 #
-#   quick   : subset of fast positions (~5 seconds), the default
+#   quick   : subset of fast positions (a few seconds), the default
 #   full    : all of tests/ffotest.scr -- takes several minutes
-#   jobs    : how many positions to solve in parallel (default 4)
 #   threads : search threads per position, i.e. scrzebra's -n
-#             (default: whatever scrzebra itself defaults to)
+#             (default: the number of processors on this machine)
 #
-# Note that the two multiply: jobs x threads processes' worth of work
-# can be running at once.
-#
-# Positions are solved in separate scrzebra processes (they share only
-# the read-only coeffs2.bin), so they can run concurrently.  A result
-# line with the elapsed time is printed as soon as each position is
-# solved, in completion order.
+# Positions are solved one at a time, each getting the whole machine.
+# The endgame search is parallel itself now, so solving several at once
+# would just make them fight over the same cores; it would also make the
+# elapsed time printed for each position meaningless, and those numbers
+# get quoted.
 #
 # Expected rows: FFO# <black discs> <white discs> <acceptable first moves>
 # FFO #59 has three optimal moves (g8, h4, e8 all win 64-0); all other
@@ -35,14 +32,28 @@ else
   now() { date +%s; }
 fi
 
-# ----- worker: solve and check one position ---------------------------
-# Invoked (via xargs) as: check_ffo.sh __worker <idx> <ffo#> <black> <white> <moves>
-# Inherits OUT and FFO_NFLAG from the parent through the environment.
-if [ "$1" = "__worker" ]; then
-  i=$2; ffo=$3; eblack=$4; ewhite=$5; emoves=$6
+# Processors online.  getconf is POSIX and answers on both Linux and
+# macOS; sysctl is the fallback for the BSDs that lack the getconf name.
+default_threads() {
+  n=$(getconf _NPROCESSORS_ONLN 2>/dev/null)
+  case "$n" in
+    ''|*[!0-9]*|0) n=$(sysctl -n hw.ncpu 2>/dev/null) ;;
+  esac
+  case "$n" in
+    ''|*[!0-9]*|0) n=2 ;;
+  esac
+  echo "$n"
+}
+
+# ----- solve and check one position -----------------------------------
+# run_position <idx> <ffo#> <black> <white> <moves>; sets `failed' on a
+# mismatch.  Runs in this shell, so it can just set the variable.
+run_position() {
+  i=$1; ffo=$2; eblack=$3; ewhite=$4; emoves=$5
 
   pos_start=$(now)
-  ( cd build/bin && ./scrzebra $FFO_NFLAG -line 1 -script ffo-pos$i.scr ffo-pos$i.out ) >/dev/null
+  ( cd build/bin && ./scrzebra -n "$THREADS" -line 1 \
+      -script ffo-pos$i.scr ffo-pos$i.out ) >/dev/null
   pos_end=$(now)
   elapsed=$(awk "BEGIN { printf \"%.1f\", $pos_end - $pos_start }")
 
@@ -50,8 +61,8 @@ if [ "$1" = "__worker" ]; then
          grep -v '^[[:space:]]*$' | head -1)
   if [ -z "$line" ]; then
     echo "FAIL  FFO#$ffo: scrzebra produced no output   (${elapsed}s)"
-    touch "$OUT.failed"
-    exit 0
+    failed=1
+    return
   fi
 
   black=$(echo "$line" | awk '{print $1}')
@@ -59,43 +70,34 @@ if [ "$1" = "__worker" ]; then
   move=$(echo "$line" | awk '{print $4}')
   if [ "$black" != "$eblack" ] || [ "$white" != "$ewhite" ]; then
     echo "FAIL  FFO#$ffo: score $black-$white, expected $eblack-$ewhite   (${elapsed}s)"
-    touch "$OUT.failed"
-  else
-    case "|$emoves|" in
-      *"|$move|"*)
-        echo "ok    FFO#$ffo: $black-$white $move   (${elapsed}s)" ;;
-      *)
-        echo "FAIL  FFO#$ffo: best move $move, expected one of $emoves   (${elapsed}s)"
-        touch "$OUT.failed" ;;
-    esac
+    failed=1
+    return
   fi
-  exit 0
-fi
+
+  case "|$emoves|" in
+    *"|$move|"*)
+      echo "ok    FFO#$ffo: $black-$white $move   (${elapsed}s)" ;;
+    *)
+      echo "FAIL  FFO#$ffo: best move $move, expected one of $emoves   (${elapsed}s)"
+      failed=1 ;;
+  esac
+}
 
 # ----- main -----------------------------------------------------------
 
 MODE=${1:-quick}
-JOBS=${2:-4}
-THREADS=$3
+THREADS=$2
 BIN=build/bin/scrzebra
 
-case "$JOBS" in
-  ''|*[!0-9]*|0)
-    echo "check_ffo: jobs must be a positive integer" >&2
-    exit 1 ;;
-esac
-
-if [ -n "$THREADS" ]; then
+if [ -z "$THREADS" ]; then
+  THREADS=$(default_threads)
+else
   case "$THREADS" in
     *[!0-9]*|0)
       echo "check_ffo: threads must be a positive integer" >&2
       exit 1 ;;
   esac
-  FFO_NFLAG="-n $THREADS"
-else
-  FFO_NFLAG=""
 fi
-export FFO_NFLAG
 
 if [ "$MODE" = "full" ]; then
   SCRIPT=tests/ffotest.scr
@@ -135,7 +137,6 @@ else
 46 28 36 b3
 59 64 0 g8|h4|e8"
 fi
-export OUT
 
 if [ ! -x "$BIN" ]; then
   echo "check_ffo: $BIN not found; run 'make scrzebra' first" >&2
@@ -145,44 +146,31 @@ fi
 if [ "$MODE" = "full" ]; then
   echo "check_ffo: solving the full FFO test suite; this takes several minutes."
 fi
-if [ -n "$THREADS" ]; then
-  echo "check_ffo: running $JOBS position(s) in parallel, $THREADS thread(s) each"
-else
-  echo "check_ffo: running $JOBS position(s) in parallel"
-fi
+echo "check_ffo: one position at a time, $THREADS search thread(s) each"
 
 # One position per line, comments stripped
 POSFILE=$OUT.positions
+rm -f "$OUT"
 grep -v '^%' "$SCRIPT" | grep -v '^[[:space:]]*$' > "$POSFILE"
 
-# Per-position script files and the worker argument list
-ARGSFILE=$OUT.args
-rm -f "$OUT" "$OUT.failed" "$ARGSFILE"
 i=0
-echo "$EXPECTED" | while read -r ffo eblack ewhite emoves; do
+suite_start=$(now)
+while read -r ffo eblack ewhite emoves; do
   i=$((i + 1))
   sed -n "${i}p" "$POSFILE" > build/bin/ffo-pos$i.scr
-  echo "__worker $i $ffo $eblack $ewhite $emoves" >> "$ARGSFILE"
-done
-
-suite_start=$(now)
-xargs -L1 -P "$JOBS" sh "$0" < "$ARGSFILE"
-suite_end=$(now)
-total=$(awk "BEGIN { printf \"%.1f\", $suite_end - $suite_start }")
-
-# Collect raw results in position order, then clean up
-n=$(wc -l < "$POSFILE")
-i=0
-while [ $i -lt "$n" ]; do
-  i=$((i + 1))
+  run_position "$i" "$ffo" "$eblack" "$ewhite" "$emoves"
   grep -v '^%' build/bin/ffo-pos$i.out 2>/dev/null | \
     grep -v '^[[:space:]]*$' | head -1 >> "$OUT"
   rm -f build/bin/ffo-pos$i.scr build/bin/ffo-pos$i.out
-done
-rm -f "$POSFILE" "$ARGSFILE"
+done <<EOF
+$EXPECTED
+EOF
+suite_end=$(now)
+total=$(awk "BEGIN { printf \"%.1f\", $suite_end - $suite_start }")
 
-if [ -f "$OUT.failed" ]; then
-  rm -f "$OUT.failed"
+rm -f "$POSFILE"
+
+if [ -n "$failed" ]; then
   echo "check_ffo: FAILED   (total ${total}s)"
   exit 1
 fi

--- a/tests/check_ffo.sh
+++ b/tests/check_ffo.sh
@@ -9,7 +9,7 @@
 # make passes these through as FFO_JOBS and FFO_THREADS.
 #
 #   quick   : subset of fast positions (~5 seconds), the default
-#   full    : all of tests/ffotest.scr -- takes a VERY long time
+#   full    : all of tests/ffotest.scr -- takes several minutes
 #   jobs    : how many positions to solve in parallel (default 4)
 #   threads : search threads per position, i.e. scrzebra's -n
 #             (default: whatever scrzebra itself defaults to)
@@ -143,7 +143,7 @@ if [ ! -x "$BIN" ]; then
 fi
 
 if [ "$MODE" = "full" ]; then
-  echo "check_ffo: solving the full FFO test suite; this takes a LONG time."
+  echo "check_ffo: solving the full FFO test suite; this takes several minutes."
 fi
 if [ -n "$THREADS" ]; then
   echo "check_ffo: running $JOBS position(s) in parallel, $THREADS thread(s) each"

--- a/tests/ffo-quick.scr
+++ b/tests/ffo-quick.scr
@@ -3,7 +3,7 @@
 %
 % A fast subset of the FFO endgame test suite (ffotest.scr):
 % positions #47, #40, #41, #42, #43, #44, #46 and #59, in that order.
-% Each solves in a few seconds; the full suite takes hours.
+% Each solves in a couple of seconds; the full suite takes minutes.
 %
 % Expected results (from http://radagast.se/othello/ffotest.html) are
 % checked by tests/check_ffo.sh.


### PR DESCRIPTION
Parallel endgame search using the Young Brothers Wait Concept.

> Builds on #12 (thread-local search state) and #13 (worker pool), both
> merged. Rebased onto master, so the diff here is only the search change.

A node searches its first move alone, and once that move has produced a
bound the remaining moves are handed to the worker pool with a null window.
Almost all of them fail low, and the sequential loop then skips those
outright instead of searching them. A move that fails high is left for the
sequential loop to re-search in order, so the score and the principal
variation still come out of exactly the same code as before.

| Commit | What it does |
|---|---|
| Step 3 | Add `search_state_save()` / `search_state_load()` |
| Step 4 | Split at the root |
| Step 5 | Split at interior nodes as well |
| — | Let the splitting thread help with its own batch |
| — | Default to two threads; `FFO_THREADS` for the test suite |
| — | Correct the runtime claims for the full FFO suite |
| — | Retire `FFO_JOBS` in favour of the search's own threads |

Root splitting alone is not enough: on FFO #49 the eldest brother dominates
the search and the root split has nothing left to parallelise. That is what
step 5 is for -- a node offers its siblings to the pool wherever it sits in
the tree, as long as enough depth remains (`PARALLEL_SPLIT_DEPTH`) for a
batch to be worth the round trip.

## Results

FFO endgame positions, 8-core arm64 Mac, `-n 1` vs `-n 8`:

| Position | 1 thread | 8 threads | Speedup |
|----------|---------:|----------:|--------:|
| FFO #45  |   12.0 s |     3.4 s |   3.5x |
| FFO #48  |    6.8 s |     2.4 s |   2.8x |
| FFO #49  |    9.8 s |     3.6 s |   2.7x |
| FFO #51  |   10.9 s |     4.0 s |   2.7x |

The default becomes `-n 2`, which is where the parallel search first pays
for itself (FFO #48 6.9s to 3.8s, #49 9.7s to 5.8s) without taking over a
machine by surprise. `-n 1` still gives the purely sequential search, and
runs every job inline on the caller.

## Correctness

Exact scores and best moves are unchanged at every thread count. The tails
of the principal variation can differ between thread counts, since the
transposition table is shared and gets filled in a different order.

Verified on the FFO quick suite at `-n 1` and `-n 8`: all eight positions
return identical scores and identical best moves. The full suite was also
run end to end -- all 21 positions pass, in 508.5s with each position given
the whole machine.

Three bugs are worth calling out, since they are the ones a reviewer should
check the fixes for:

* **Flip stack.** A job never unmakes its move, so it has to restore the
  flip stack pointer by hand. Left alone it climbs with every job and
  eventually runs off the end of `global_flip_stack`, which shows up as the
  same NULL dereference in `unmake_move` that the arm64 flip bug produced.
* **Re-entrancy.** A job can recurse into a node that wants to split as
  well, which would reuse the shared batch and re-enter a pool that is
  already busy. A thread now records that it is inside a job, and a node
  reached from there does not split, which is the same rule workers already
  followed. This is also what lets the splitting thread take part in its own
  batch instead of watching a single worker do the siblings, which is what
  makes `-n 2` worth anything -- and it is why that commit changes `end.c`
  and `threads.c` together rather than having landed the pool half in #13.
* **Selectivity flag.** When the sequential loop takes a score the pool
  already proved, it skips the search that would otherwise have set
  `child_selective_cutoff`. Leaving it unset let an uninitialised value into
  the hash entry, which produced confidently wrong scores as soon as
  splitting reached far enough down the tree to make it common. The flag is
  now carried back from the job alongside the score.

## The test suite stops solving positions in parallel

`FFO_JOBS` used to solve several positions at once in separate processes,
which was the right thing when the endgame search was single-threaded. It is
not any more: the two forms of parallelism compete for the same cores, and
the per-position elapsed times the script prints stop meaning anything --
which matters, because those numbers are exactly what this PR and the README
quote.

Full suite, 8-core arm64 Mac:

| | `FFO_JOBS=4`, `-n 2` | one at a time, `-n 8` |
|---|---:|---:|
| total   | 423.5 s | 508.5 s |
| FFO #50 |  44.8 s |  16.4 s |
| FFO #53 |  97.4 s |  45.4 s |
| FFO #55 | 398.4 s | 196.5 s |

So the suite is about 20% slower in wall clock, and every number in it is
now real -- #50 was being reported at 2.7x its actual cost. For a suite that
exists to be quoted, that is the better trade. The quick subset goes the
other way (2.0s to 3.4s) because its positions are too small for eight
threads to pay for themselves, but 1.4 seconds is not a reason to keep a
knob that distorts the full run.

`check_ffo.sh` now takes the thread count as its second argument instead of
a job count, and defaults to one thread per processor rather than leaving
`scrzebra` on its own default of two:

```
make test FFO_THREADS=4
```

It is a plain makefile assignment rather than `?=`, so a variable of the
same name left exported in someone's environment cannot quietly change what
the test does, while a command line assignment still wins.

## Testing

`make test` runs the flip test, the pool test and the FFO quick check; all
pass, with no compiler warnings at `-O3`.
