### PR TITLE
Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.claude/
 build/
 current.gam
 current.mov


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` to prevent local Claude Code settings, conversation logs, and workspace configuration files from being tracked in the repository.