### PR TITLE
Fix out-of-bounds accesses found by fuzzing the fork

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -201,7 +201,8 @@ global_terminate( void ) {
 
 static void
 setup_game( const char *file_name, int *side_to_move ) {
-  char buffer[65];
+  /* 64 board characters, CR, LF and the terminator all have to fit. */
+  char buffer[70];
   int i, j;
   int pos, token;
   FILE *stream;
@@ -224,7 +225,7 @@ setup_game( const char *file_name, int *side_to_move ) {
     stream = fopen( file_name, "r" );
     if ( stream == NULL )
       fatal_error( "%s '%s'\n", GAME_LOAD_ERROR, file_name );
-    fgets( buffer, 70, stream );
+    fgets( buffer, sizeof buffer, stream );
     token = 0;
     for ( i = 1; i <= 8; i++ )
       for ( j = 1; j <= 8; j++ ) {
@@ -243,7 +244,7 @@ setup_game( const char *file_name, int *side_to_move ) {
 	  break;
 	default:
 #if TEXT_BASED
-	  printf( "%s '%c' %s\n", BAD_CHARACTER_ERROR, buffer[pos],
+	  printf( "%s '%c' %s\n", BAD_CHARACTER_ERROR, buffer[token],
 		  GAME_FILE_TEXT);
 #endif
 	  break;
@@ -261,6 +262,16 @@ setup_game( const char *file_name, int *side_to_move ) {
 		   GAME_FILE_TEXT);
   }
   disks_played = disc_count( BLACKSQ ) + disc_count( WHITESQ ) - 4;
+
+  /* No legal position has fewer than four discs, so this only rejects a
+     malformed board file -- but the file is arbitrary user input, and
+     DISKS_PLAYED indexes the move lists, the hash stack and the move
+     string built by play_game().  Left unchecked, such a file makes it
+     negative and the game ends without a word rather than failing. */
+
+  if ( disks_played < 0 )
+    fatal_error( "Board file '%s' holds fewer than four discs\n",
+		 file_name );
 
   determine_hash_values( *side_to_move, board );
 

--- a/src/learn.c
+++ b/src/learn.c
@@ -16,6 +16,7 @@
 #include <string.h>
 #include "constant.h"
 #include "end.h"
+#include "error.h"
 #include "game.h"
 #include "globals.h"
 #include "hash.h"
@@ -149,6 +150,18 @@ learn_game( int game_length, int private_game, int save_database ) {
       side_to_move = OPP( side_to_move );
       generate_all( side_to_move );
     }
+
+    /* Nothing checks GAME_MOVE before this loop.  GAME_LEARNABLE exists
+       for the purpose but is never called from anywhere, and play_game()
+       reaches learn_game() on use_learning alone.  A game set up from a
+       board file stores no moves for the discs that were already on the
+       board, so those entries are still ILLEGAL and MAKE_MOVE indexes
+       the board with -1: 'zebra -learn 2 16 -g <board>' segfaults. */
+
+    if ( game_move[i] == ILLEGAL )
+      fatal_error( "Cannot learn game: move %d of %d was never stored\n",
+		   i + 1, game_length );
+
     (void) make_move( side_to_move, game_move[i], TRUE );
     if ( side_to_move == WHITESQ )
       game_move[i] = -game_move[i];

--- a/src/osfbook.c
+++ b/src/osfbook.c
@@ -1224,6 +1224,12 @@ nega_scout( int depth, int allow_mpc, int side_to_move,
      and its score when searched to depth DEPTH.
      This is done using standard negascout with iterative deepening. */
 
+  /* DEPTH == 0 makes the loop below exit before its first iteration,
+     leaving *BEST_INDEX at whatever the caller passed in; it is
+     dereferenced unconditionally once the loop is done. */
+
+  *best_index = 0;
+
   for ( curr_depth = 2 - (depth % 2); curr_depth <= depth; curr_depth += 2 ) {
     low_score = -INFINITE_EVAL;
     curr_alpha = -INFINITE_EVAL;
@@ -4041,7 +4047,14 @@ fill_move_alternatives( int side_to_move,
       score = 0;
     }
 
+    /* A move can be feasible without a book node behind it: the branch
+       above accepts the deviation move even when the child is missing.
+       SLOT is then NOT_AVAILABLE or refers to an empty slot, and both
+       sentinels are -1, so neither may be used as an index. */
+
     if ( child_feasible && (score == 0) &&
+	 (slot != NOT_AVAILABLE) &&
+	 (book_hash_table[slot] != EMPTY_HASH_SLOT) &&
 	 !(node[index].flags & WLD_SOLVED) &&
 	 (node[book_hash_table[slot]].flags & WLD_SOLVED) ) {
       /* Check if this is a book draw that should be avoided, i.e., one

--- a/src/zebra.c
+++ b/src/zebra.c
@@ -809,7 +809,11 @@ play_game( const char *file_name,
   if ( move_file != NULL ) {
     char *newline_pos;
 
-    fgets( line_buffer, sizeof line_buffer, move_file );
+    /* An empty or already exhausted move file leaves LINE_BUFFER
+       untouched, and everything below reads it as a string. */
+
+    if ( fgets( line_buffer, sizeof line_buffer, move_file ) == NULL )
+      line_buffer[0] = 0;
     newline_pos = strchr( line_buffer, '\n' );
     if ( newline_pos != NULL )
       *newline_pos = 0;


### PR DESCRIPTION
Memory-safety bugs found by fuzzing [panstromek's fork](https://github.com/panstromek/zebra). They are in Gunnar's original code, so all of them are still here. Each was reproduced against the unmodified tree with `-fsanitize=address,undefined`.

| Fix | Problem |
|---|---|
| `game.c` buffer | `char buffer[65]` read into with `fgets(buffer, 70, ...)`. **Any ordinary board file overflows it** — 64 characters plus a newline is a 66-byte write. |
| `game.c` `buffer[pos]` → `buffer[token]` | A typo. `pos` is a board index between 11 and 88, so reporting a bad character on the last two ranks reads off the end. |
| `game.c` disc count | Input validation: a malformed board file with fewer than four discs makes `disks_played` negative, and `generate_all()` then writes `move_count[-2]`. No legal position reaches this, but the file is arbitrary user input and `setup_game()` already rejects a bad side-to-move character the same way. |
| `zebra.c` `line_buffer` | `strchr()`/`strlen()` run over it whether or not the `fgets()` filling it succeeded. |
| `osfbook.c` `nega_scout` | `*best_index` is dereferenced after a loop that does not execute at all when `depth` is 0. |
| `osfbook.c` `fill_move_alternatives` | `node[book_hash_table[slot]]` is reached with no book node behind the move. |
| `learn.c` | **`game_learnable()` exists to validate `game_move[]` and is never called from anywhere**, so `learn_game()` plays out entries that are still `ILLEGAL` and hands `make_move()` a `-1`. |

The buffer overflow, for scale:

```
ERROR: AddressSanitizer: stack-buffer-overflow
WRITE of size 66 ... [32, 97) 'buffer' (line 204)
```

The `learn.c` one is a hard crash, at an entirely ordinary cutoff — `zebra -learn 2 16 -g <board>`:

```
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
  #2 in learn_game learn.c:159
SUMMARY: AddressSanitizer: SEGV cntflip.c:56 in AnyFlips_compact
```

## Two places this differs from the fork

**`osfbook.c`** — `NOT_AVAILABLE` and `EMPTY_HASH_SLOT` are **both `-1`**. The fork guards only `book_hash_table[slot] != EMPTY_HASH_SLOT`, which still leaves `book_hash_table[-1]`. The guard here covers `slot` itself.

**`move_vec[121]`** is left alone. With `disks_played` non-negative the last move of a full game writes bytes 118 to 120, so 121 is exactly enough. The fork widens it to 123, which only papers over the negative index.

## Not here

The `[61]` → `[62]` array sizes (#17), the signed-shift UB in `bitbtest.c`/`thordb.c`/`patterns.c`/`stable.c`/`myrandom.c` (wants its own change with a UBSan build behind it), and everything c2rust-specific — emptying `#define INLINE __inline__` is a performance regression here, and the fork's `make_move()`/`unmake_move()` guards sit in the hottest functions in the engine and corrupt state rather than crash.

## Testing

`make test` passes. A game from a board file is unchanged (28-36, 2554 nodes).

Found by panstromek, GPL-2 the same as this tree. Reimplemented rather than cherry-picked — the fork predates the `src/` reorganisation and is 14 commits behind.

Co-authored-by: panstromek <panstromek@seznam.cz>
