### PR TITLE
Size the stage-indexed arrays for the stage that is actually reached

### DIFF
--- a/src/midgame.c
+++ b/src/midgame.c
@@ -80,7 +80,11 @@ static _Thread_local int do_check_midgame_abort = TRUE;
 static _Thread_local int counter_phase;
 static _Thread_local int apply_perturbation = TRUE;
 static int perturbation_amplitude = 0;
-static _Thread_local int stage_reached[61], stage_score[61];
+/* Indexed by BASE_STAGE + DEPTH, i.e. the stage the search ends at.
+   game.c keeps deepening while DISKS_PLAYED + the depth is at most 61,
+   so the last index in use is 61 and 62 entries are needed. */
+
+static _Thread_local int stage_reached[62], stage_score[62];
 static int score_perturbation[100];
 static _Thread_local int feas_index_list[64][64];
 
@@ -97,7 +101,7 @@ setup_midgame( void ) {
 
   allow_midgame_hash_probe = TRUE;
   allow_midgame_hash_update = TRUE;
-  for ( i = 0; i <= 60; i++ )
+  for ( i = 0; i <= 61; i++ )
     stage_reached[i] = FALSE;
 
   calculate_perturbation();
@@ -1375,7 +1379,8 @@ middle_game( int side_to_move, int max_depth,
     /* Adjust the eval for oscillations odd/even by simply averaging the
        last two stages (if they are available). */
 
-    if ( stage_reached[base_stage + depth] &&
+    if ( (base_stage + depth >= 1) &&
+	 stage_reached[base_stage + depth] &&
 	 stage_reached[base_stage + depth - 1] && update_evals ) {
       if ( side_to_move == BLACKSQ )
 	adjusted_val = (stage_score[base_stage + depth] +

--- a/src/search.c
+++ b/src/search.c
@@ -35,8 +35,12 @@ int root_eval;
 int force_return;
 int full_pv_depth;
 int full_pv[120];
-_Thread_local int list_inherited[61];
-_Thread_local int sorted_move_order[64][64];  /* 61*60 used */
+/* Indexed by the stage a search ends at, which is DISKS_PLAYED plus the
+   search depth.  game.c lets that reach 61 -- one past the last real
+   stage of a game -- so 62 entries are needed, not 61. */
+
+_Thread_local int list_inherited[62];
+_Thread_local int sorted_move_order[64][64];  /* 62*60 used */
 _Thread_local Board evals[61];
 _Thread_local CounterType nodes;
 CounterType total_nodes;
@@ -80,11 +84,11 @@ static void
 init_move_lists( void ) {
   int i, j;
 
-  for ( i = 0; i <= 60; i++ ) {
+  for ( i = 0; i <= 61; i++ ) {
     for ( j = 0; j < MOVE_ORDER_SIZE; j++ )
       sorted_move_order[i][j] = position_list[j];
   }
-  for ( i = 0; i <= 60; i++ )
+  for ( i = 0; i <= 61; i++ )
     list_inherited[i] = FALSE;
 }
 


### PR DESCRIPTION
Stacked on #16 — review that first.

`stage_reached[]`, `stage_score[]` and `list_inherited[]` hold 61 entries but are indexed by the stage a search **ends** at, `disks_played + depth`. `game.c` deepens while

```c
(midgame_depth <= max_depth) && (midgame_depth + disks_played <= 61)
```

so the index reaches 61 and all three are written one past the end. They are `_Thread_local`, so the write lands in the neighbouring TLS object — for `list_inherited` that is `sorted_move_order`, i.e. silent corruption of the move ordering rather than a crash.

## The bound was measured

The fork just grows the arrays, so I instrumented `middle_game()` and `inherit_move_lists()` and played games with the endgame solver disabled (`-l <mid> 0 0`), which keeps the midgame search running to the end:

```
PROBE midgame hi base_stage+depth=61
PROBE inherit hi stage=61
```

Ordinary self-play only gets to 60, which is why this has never been noticed.

## Why grow the arrays rather than tighten the loop

Stage 61 is one past the last real stage of a game, so changing the condition to `<= 60` is the other honest repair — but it changes how many deepening iterations the late midgame gets, and so changes what the engine plays. Growing the arrays does not: a deterministic self-play game (`-l 8 8 8 8 8 8 -r 0 -b 0`) gives **byte-identical output** before and after.

## Also here

* `init_move_lists()` seeded only rows 0 to 60 of `sorted_move_order`, leaving row 61 to be filled by `inherit_move_lists()` before first use. Seeded with the rest now so the invariant does not depend on call order.
* `middle_game()` reads `stage_reached[base_stage + depth - 1]` unguarded, though the two analogous reads at `- 2` are both guarded. Depth 0 on an empty board indexes it with `-1`.

## Difference from the fork

It grows the arrays too, but then adds `if (stage >= 61) return;` to `inherit_move_lists()` — discarding the very entry the extra slot was added for.

`make test` passes.

Found by panstromek, GPL-2 the same as this tree; the bound was established here rather than taken on trust.

Co-authored-by: panstromek <panstromek@seznam.cz>
