### PR TITLE
Ask game_learnable() before learning a game

### DIFF
--- a/src/zebra.c
+++ b/src/zebra.c
@@ -1157,9 +1157,20 @@ play_game( const char *file_name,
   repeat--;
 
   toggle_abort_check( FALSE );
-  if ( use_learning && !one_position_only )
-    learn_game( disks_played, (skill[BLACKSQ] != 0) && (skill[WHITESQ] != 0),
-		repeat == 0 );
+  if ( use_learning && !one_position_only ) {
+
+    /* A game begun from a board file has no moves stored behind the discs
+       it started with, so it is not learnable.  game_learnable() inspects
+       only the moves before the learning cutoff, so learn_game() still has
+       to check the ones it replays.  FINISHED is TRUE: the only way out of
+       the loop above without finishing is ONE_POSITION_ONLY. */
+
+    if ( game_learnable( TRUE, disks_played ) )
+      learn_game( disks_played, (skill[BLACKSQ] != 0) && (skill[WHITESQ] != 0),
+		  repeat == 0 );
+    else
+      puts( "Game not learnable - not added to the opening book" );
+  }
   toggle_abort_check( TRUE );
 
   if ( repeat > 0 )


### PR DESCRIPTION
Stacked on #17, which is stacked on #16.

`game_learnable()` is Zebra's own test for whether a finished game is fit to go into the opening book. It is exported from `learn.h` for the GUI to call — **the text interface never called it**, and `play_game()` reached `learn_game()` on `use_learning` alone.

The case that matters is a game begun from a board file. The moves behind the discs already on the board were never played, so `store_move()` never recorded them and `game_move[]` still holds `ILLEGAL` there — yet the game was learned as though those moves were known. Before the guard added in #16 that was a segfault:

```
zebra -learn 2 16 -g <board>
  SUMMARY: AddressSanitizer: SEGV cntflip.c:56 in AnyFlips_compact
```

With the guard it became a fatal error — honest, but it still kills a run that had no business being learned. Asking the question up front lets the game finish and simply skips the book update.

## The two checks are not redundant

`game_learnable()` inspects only the moves **before the learning cutoff**, so it is a gate on what reaches the book. `learn_game()` replays **every** move of the game, so it still has to check the ones it replays. Keeping both is deliberate.

## `finished`

`TRUE`, because the game is always over at this point: the one way out of the loop above without finishing is `one_position_only`, which already excludes this branch.

## Behaviour

Ordinary self-play is unaffected — every move is stored from the start, so `game_learnable()` says yes and `learn_game()` runs exactly as before. A game from a board file now finishes normally and reports:

```
Game not learnable - not added to the opening book
```

`make test` passes.
