### PR TITLE
Reject -learn with -b 0 up front

### DIFF
--- a/src/zebra.c
+++ b/src/zebra.c
@@ -629,6 +629,17 @@ main( int argc, char *argv[] ) {
     exit( EXIT_FAILURE );
   }
 
+  /* The learning database is the opening book, and init_learn() -- which
+     is what names it -- runs only when the book is in use.  Without it
+     the name stays empty and the game is played out in full before
+     failing on a database called ''. */
+
+  if ( use_learning && !use_book ) {
+    printf( "-learn writes what it learns back into the opening book, "
+	    "so it cannot be combined with -b 0\n" );
+    exit( EXIT_FAILURE );
+  }
+
   global_setup( use_random, hash_bits );
   threads_init( n_threads );
   init_thor_database();


### PR DESCRIPTION
Stacked on #18.

The learning database *is* the opening book. `init_learn()` is what records the database name, and it runs only when the book is in use:

```c
if ( use_book )
  init_learn( "book.bin", TRUE );
```

So `-learn` with `-b 0` leaves `database_name` empty, and the run plays an **entire game** before dying on a database called `''`:

```
zebra -l 2 2 2 2 2 2 -b 0 -learn 2 16
...
Fatal error: Could not create database file ''
```

The combination cannot be made to work — there is nowhere for the learned game to go — so it is refused next to the existing `hash_bits` check, before any setup runs. The same command now exits in 0.4 s with:

```
-learn writes what it learns back into the opening book, so it cannot be combined with -b 0
```

Pre-existing behaviour, unrelated to the fixes in #16–#18; it just turned up while testing them.

`make test` passes.
