### PR TITLE
Incremental evaluation and bitboard moves in the midgame

### DIFF
--- a/src/bitbmob.c
+++ b/src/bitbmob.c
@@ -68,6 +68,20 @@ generate_all_c( const BitBoard my_bits,
 }
 
 
+/*
+  BITBOARD_MOVES
+  Every square where the side to move has a legal move.  A move is
+  legal exactly when it turns a disc, so this is the same set the
+  array-board test produces, one square at a time.
+*/
+
+BitBoard
+bitboard_moves( const BitBoard my_bits,
+		const BitBoard opp_bits ) {
+  return generate_all_c( my_bits, opp_bits );
+}
+
+
 int
 bitboard_mobility( const BitBoard my_bits,
 		   const BitBoard opp_bits ) {

--- a/src/bitbmob.h
+++ b/src/bitbmob.h
@@ -20,6 +20,12 @@
 
 
 
+BitBoard
+bitboard_moves( const BitBoard my_bits,
+		const BitBoard opp_bits );
+
+
+
 int
 weighted_mobility( const BitBoard my_bits,
 		   const BitBoard opp_bits );

--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -19,6 +19,7 @@
 
 BitBoard square_mask[100];
 int bit_position[100];
+int square_of_bit[64];
 FlipRays flip_rays[64];
 
 
@@ -128,6 +129,7 @@ init_bitboard( void ) {
       int shift = 8 * (i - 1) + (j - 1);
       square_mask[pos] = 1ull << shift;
       bit_position[pos] = shift;
+      square_of_bit[shift] = pos;
     }
 
   for ( i = 1; i <= 8; i++ )

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -22,6 +22,24 @@
 typedef unsigned long long BitBoard;
 
 
+/* The index of the lowest set bit.  Undefined for zero, so the loops
+   that use it test the word first. */
+
+#if defined( __GNUC__ )
+#define FIRST_BIT( x )  __builtin_ctzll( x )
+#else
+static INLINE int
+FIRST_BIT( BitBoard x ) {
+  int n = 0;
+  while ( (x & 1) == 0 ) {
+    x >>= 1;
+    n++;
+  }
+  return n;
+}
+#endif
+
+
 /* The operation macros predate the 64-bit representation, when every
    one of them took two statements.  Kept so their call sites read the
    same as they always have. */
@@ -49,8 +67,10 @@ typedef unsigned long long BitBoard;
 
 extern BitBoard square_mask[100];
 
-/* Conversion from a board coordinate (11..88) to the bit index. */
+/* Conversion from a board coordinate (11..88) to the bit index, and
+   back again. */
 extern int bit_position[100];
+extern int square_of_bit[64];
 
 /* The squares a flip line through a given square can run over,
    one mask per ray.  The "down" rays run towards higher bit indices

--- a/src/bitbtest.c
+++ b/src/bitbtest.c
@@ -49,7 +49,8 @@ highest_guarded_bit( BitBoard b ) {
 
 
 int
-TestFlips_bitboard( int sq, BitBoard my_bits, BitBoard opp_bits ) {
+TestFlips_bitboard_to( int sq, BitBoard my_bits, BitBoard opp_bits,
+		       BitBoard *new_my_bits ) {
   const FlipRays *r = &flip_rays[bit_position[sq]];
   BitBoard flips = 0;
   BitBoard ray, t, f;
@@ -76,7 +77,20 @@ TestFlips_bitboard( int sq, BitBoard my_bits, BitBoard opp_bits ) {
     flips |= f;
   }
 
-  bb_flips = my_bits | flips | square_mask[sq];
+  *new_my_bits = my_bits | flips | square_mask[sq];
 
   return non_iterative_popcount( flips );
+}
+
+
+/*
+  The endgame keeps the result in BB_FLIPS and reads it back some way
+  after the call -- across a shallow midgame search, in the
+  fastest-first ordering -- so anything that flips discs on the side
+  must leave that variable alone and use TestFlips_bitboard_to.
+*/
+
+int
+TestFlips_bitboard( int sq, BitBoard my_bits, BitBoard opp_bits ) {
+  return TestFlips_bitboard_to( sq, my_bits, opp_bits, &bb_flips );
 }

--- a/src/bitbtest.h
+++ b/src/bitbtest.h
@@ -22,9 +22,17 @@
 
 extern _Thread_local BitBoard bb_flips;
 
-/* SQ is a board coordinate, 11..88. */
+/* SQ is a board coordinate, 11..88.  The mover's discs with the
+   turned ones added land in BB_FLIPS, which the endgame reads back
+   well after the call; callers that only want the flips of a move
+   they are making must use the _TO form and keep out of that
+   variable. */
 int
 TestFlips_bitboard( int sq, BitBoard my_bits, BitBoard opp_bits );
+
+int
+TestFlips_bitboard_to( int sq, BitBoard my_bits, BitBoard opp_bits,
+		       BitBoard *new_my_bits );
 
 
 

--- a/src/end.c
+++ b/src/end.c
@@ -213,21 +213,6 @@ TestFlips_wrapper( int sq,
   without maintaining the board array, the flip stack or DoFlips_hash.
 */
 
-#if defined( __GNUC__ )
-#define FIRST_BIT_64( x )  __builtin_ctzll( x )
-#else
-static int
-FIRST_BIT_64( BitBoard x ) {
-  int n = 0;
-  while ( (x & 1) == 0 ) {
-    x >>= 1;
-    n++;
-  }
-  return n;
-}
-#endif
-
-
 /*
   END_HASH_DIFF
   Compute the incremental hash-key update for COLOR playing SQ,
@@ -246,7 +231,7 @@ end_hash_diff( const BitBoard new_my_bits, const BitBoard my_bits,
 
   fl = (new_my_bits ^ my_bits) & ~square_mask[sq];
   while ( fl != 0 ) {
-    bit = FIRST_BIT_64( fl );
+    bit = FIRST_BIT( fl );
     fl &= fl - 1;
     index = 10 * (bit / 8 + 1) + (bit % 8) + 1;
     d1 ^= hash_flip1[index];

--- a/src/enddev.c
+++ b/src/enddev.c
@@ -132,6 +132,7 @@ main( int argc, char *argv[] ) {
 	    disks_played + 4 );
 
     determine_hash_values( side_to_move, board );
+    determine_pattern_indices();
 
     generate_all( side_to_move );
     if ( move_count[disks_played] == 0 ) {

--- a/src/enddev.c
+++ b/src/enddev.c
@@ -133,6 +133,7 @@ main( int argc, char *argv[] ) {
 
     determine_hash_values( side_to_move, board );
     determine_pattern_indices();
+    set_board_bits();
 
     generate_all( side_to_move );
     if ( move_count[disks_played] == 0 ) {

--- a/src/game.c
+++ b/src/game.c
@@ -274,6 +274,7 @@ setup_game( const char *file_name, int *side_to_move ) {
 		 file_name );
 
   determine_hash_values( *side_to_move, board );
+  determine_pattern_indices();
 
   /* Make the game score look right */
 
@@ -396,6 +397,7 @@ ponder_move( int side_to_move, int book, int mid, int exact, int wld ) {
   start_move( 0, 0, disc_count( BLACKSQ ) + disc_count( WHITESQ ) );
   clear_ponder_times();
   determine_hash_values( side_to_move, board );
+  determine_pattern_indices();
 
   reset_counter( &nodes );
 
@@ -549,6 +551,7 @@ extended_compute_move( int side_to_move, int book_only,
   start_move( 0, 0, disc_count( BLACKSQ ) + disc_count( WHITESQ ) );
   clear_ponder_times();
   determine_hash_values( side_to_move, board );
+  determine_pattern_indices();
 
   empties = 60 - disks_played;
 
@@ -1000,6 +1003,7 @@ perform_extended_solve( int side_to_move, int actual_move,
   start_move( 0, 0, disc_count( BLACKSQ ) + disc_count( WHITESQ ) );
   clear_ponder_times();
   determine_hash_values( side_to_move, board );
+  determine_pattern_indices();
   reset_counter( &nodes );
 
   /* Set search depths that result in Zebra solving after a brief
@@ -1181,6 +1185,7 @@ compute_move( int side_to_move,
   init_moves();
   generate_all( side_to_move );
   determine_hash_values( side_to_move, board );
+  determine_pattern_indices();
 
   calculate_perturbation();
 

--- a/src/game.c
+++ b/src/game.c
@@ -275,6 +275,7 @@ setup_game( const char *file_name, int *side_to_move ) {
 
   determine_hash_values( *side_to_move, board );
   determine_pattern_indices();
+  set_board_bits();
 
   /* Make the game score look right */
 
@@ -398,6 +399,7 @@ ponder_move( int side_to_move, int book, int mid, int exact, int wld ) {
   clear_ponder_times();
   determine_hash_values( side_to_move, board );
   determine_pattern_indices();
+  set_board_bits();
 
   reset_counter( &nodes );
 
@@ -552,6 +554,7 @@ extended_compute_move( int side_to_move, int book_only,
   clear_ponder_times();
   determine_hash_values( side_to_move, board );
   determine_pattern_indices();
+  set_board_bits();
 
   empties = 60 - disks_played;
 
@@ -1004,6 +1007,7 @@ perform_extended_solve( int side_to_move, int actual_move,
   clear_ponder_times();
   determine_hash_values( side_to_move, board );
   determine_pattern_indices();
+  set_board_bits();
   reset_counter( &nodes );
 
   /* Set search depths that result in Zebra solving after a brief
@@ -1186,6 +1190,7 @@ compute_move( int side_to_move,
   generate_all( side_to_move );
   determine_hash_values( side_to_move, board );
   determine_pattern_indices();
+  set_board_bits();
 
   calculate_perturbation();
 

--- a/src/getcoeff.c
+++ b/src/getcoeff.c
@@ -54,6 +54,13 @@
 /* Calculate cycle counts for the eval function? */
 #define TIME_EVAL             0
 
+/* Check the incrementally maintained pattern indices against a
+   recomputation from the board at every evaluation.  Very slow;
+   build with -DVERIFY_INCREMENTAL_EVAL=1 to switch it on. */
+#ifndef VERIFY_INCREMENTAL_EVAL
+#define VERIFY_INCREMENTAL_EVAL   0
+#endif
+
 
 
 typedef struct {
@@ -1115,2669 +1122,482 @@ pattern_evaluation( int side_to_move ) {
 
   /* The pattern features. */
 
-  if ( side_to_move == BLACKSQ ) {
-#ifdef USE_PENTIUM_ASM
-    int pattern0;
-    int pattern1;
-    int pattern2;
-    int pattern3;
-    asm( 
-         "movl _board+288,%0\n\t"
-         "movl _board+308,%1\n\t"
-         "movl _board+108,%2\n\t"
-         "movl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+108,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+88,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+288,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+324,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+352,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+72,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+352,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+284,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+312,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+68,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+348,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+244,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+272,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+64,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+344,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+204,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+232,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+60,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+340,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+164,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+192,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+56,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+336,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+124,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+152,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+52,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+332,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+84,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+112,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+48,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+328,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+72,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+44,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+324,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].afile2x[pattern0];
-    score += set[eval_phase].afile2x[pattern1];
-    score += set[eval_phase].afile2x[pattern2];
-    score += set[eval_phase].afile2x[pattern3];
-    asm( 
-         "movl _board+328,%0\n\t"
-         "movl _board+348,%1\n\t"
-         "movl _board+112,%2\n\t"
-         "movl _board+312,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+288,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+308,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+108,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+248,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+268,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+104,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+304,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+208,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+228,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+100,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+300,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+168,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+188,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+96,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+296,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+128,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+148,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+92,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+292,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+108,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+88,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+288,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+68,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+84,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+284,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].bfile[pattern0];
-    score += set[eval_phase].bfile[pattern1];
-    score += set[eval_phase].bfile[pattern2];
-    score += set[eval_phase].bfile[pattern3];
-    asm( 
-         "movl _board+332,%0\n\t"
-         "movl _board+344,%1\n\t"
-         "movl _board+152,%2\n\t"
-         "movl _board+272,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+292,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+304,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+148,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+268,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+252,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+264,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+144,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+264,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+212,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+224,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+140,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+260,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+172,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+184,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+136,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+256,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+132,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+144,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+132,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+252,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+92,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+104,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+128,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+248,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+52,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+64,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+124,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+244,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].cfile[pattern0];
-    score += set[eval_phase].cfile[pattern1];
-    score += set[eval_phase].cfile[pattern2];
-    score += set[eval_phase].cfile[pattern3];
-    asm( 
-         "movl _board+336,%0\n\t"
-         "movl _board+340,%1\n\t"
-         "movl _board+192,%2\n\t"
-         "movl _board+232,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+296,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+300,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+188,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+228,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+256,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+260,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+184,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+224,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+216,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+220,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+180,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+220,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+176,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+180,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+176,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+216,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+136,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+140,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+172,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+212,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+96,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+100,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+168,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+208,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+56,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+60,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+164,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+204,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].dfile[pattern0];
-    score += set[eval_phase].dfile[pattern1];
-    score += set[eval_phase].dfile[pattern2];
-    score += set[eval_phase].dfile[pattern3];
-    asm( 
-         "movl _board+352,%0\n\t"
-         "movl _board+324,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+308,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+288,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+264,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+252,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+220,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+216,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+176,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+180,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+132,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+144,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+108,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+72,%1"
-         : "=r" (pattern0), "=r" (pattern1) : );
-    score += set[eval_phase].diag8[pattern0];
-    score += set[eval_phase].diag8[pattern1];
-    asm( 
-         "movl _board+312,%0\n\t"
-         "movl _board+348,%1\n\t"
-         "movl _board+284,%2\n\t"
-         "movl _board+328,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+268,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+304,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+248,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+292,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+224,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+260,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+212,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+256,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+180,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+216,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+176,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+220,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+136,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+172,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+140,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+184,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+92,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+128,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+104,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+148,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+84,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+68,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+112,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].diag7[pattern0];
-    score += set[eval_phase].diag7[pattern1];
-    score += set[eval_phase].diag7[pattern2];
-    score += set[eval_phase].diag7[pattern3];
-    asm( 
-         "movl _board+272,%0\n\t"
-         "movl _board+344,%1\n\t"
-         "movl _board+244,%2\n\t"
-         "movl _board+332,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+228,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+300,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+208,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+296,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+184,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+256,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+172,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+260,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+140,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+212,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+136,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+224,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+96,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+168,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+100,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+188,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+52,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+124,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+64,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+152,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].diag6[pattern0];
-    score += set[eval_phase].diag6[pattern1];
-    score += set[eval_phase].diag6[pattern2];
-    score += set[eval_phase].diag6[pattern3];
-    asm( 
-         "movl _board+232,%0\n\t"
-         "movl _board+340,%1\n\t"
-         "movl _board+204,%2\n\t"
-         "movl _board+336,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+188,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+296,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+168,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+300,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+144,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+252,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+132,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+264,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+100,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+208,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+96,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+228,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+56,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+164,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+60,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+192,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].diag5[pattern0];
-    score += set[eval_phase].diag5[pattern1];
-    score += set[eval_phase].diag5[pattern2];
-    score += set[eval_phase].diag5[pattern3];
-    asm( 
-         "movl _board+192,%0\n\t"
-         "movl _board+336,%1\n\t"
-         "movl _board+164,%2\n\t"
-         "movl _board+340,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+148,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+292,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+128,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+304,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+104,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+248,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+92,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+268,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+60,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+204,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+56,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+232,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].diag4[pattern0];
-    score += set[eval_phase].diag4[pattern1];
-    score += set[eval_phase].diag4[pattern2];
-    score += set[eval_phase].diag4[pattern3];
-    asm( 
-         "movl _board+132,%0\n\t"
-         "movl _board+252,%1\n\t"
-         "movl _board+144,%2\n\t"
-         "movl _board+264,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+128,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+248,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+148,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+268,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+124,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+244,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+152,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+272,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+92,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+292,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+104,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+304,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+288,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+108,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+84,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+284,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+112,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+312,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+52,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+332,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+64,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+344,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+328,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+68,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+348,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+324,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+72,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+352,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].corner33[pattern0];
-    score += set[eval_phase].corner33[pattern1];
-    score += set[eval_phase].corner33[pattern2];
-    score += set[eval_phase].corner33[pattern3];
-    asm( 
-         "movl _board+100,%0\n\t"
-         "movl _board+300,%1\n\t"
-         "movl _board+96,%2\n\t"
-         "movl _board+296,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+96,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+296,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+100,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+300,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+92,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+292,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+104,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+304,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+288,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+108,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+84,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+284,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+112,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+312,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+60,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+340,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+56,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+336,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+56,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+336,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+60,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+340,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+52,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+332,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+64,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+344,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+328,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+68,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+348,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+324,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+72,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+352,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].corner52[pattern0];
-    score += set[eval_phase].corner52[pattern1];
-    score += set[eval_phase].corner52[pattern2];
-    score += set[eval_phase].corner52[pattern3];
-    asm( 
-         "movl _board+208,%0\n\t"
-         "movl _board+228,%1\n\t"
-         "movl _board+168,%2\n\t"
-         "movl _board+188,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+168,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+188,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+208,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+228,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+128,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+148,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+248,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+268,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+108,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+288,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+68,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+328,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+348,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+204,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+232,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+164,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+192,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+164,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+192,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+204,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+232,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+124,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+152,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+244,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+272,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+84,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+112,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+284,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+312,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+72,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+324,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+352,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].corner52[pattern0];
-    score += set[eval_phase].corner52[pattern1];
-    score += set[eval_phase].corner52[pattern2];
-    score += set[eval_phase].corner52[pattern3];
-#else
-  int pattern0;
-  pattern0 = board[72];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[81];
-  pattern0 = 3 * pattern0 + board[71];
-  pattern0 = 3 * pattern0 + board[61];
-  pattern0 = 3 * pattern0 + board[51];
-  pattern0 = 3 * pattern0 + board[41];
-  pattern0 = 3 * pattern0 + board[31];
-  pattern0 = 3 * pattern0 + board[21];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].afile2x[pattern0] );
-#endif
-  score += set[eval_phase].afile2x[pattern0];
-  pattern0 = board[77];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[88];
-  pattern0 = 3 * pattern0 + board[78];
-  pattern0 = 3 * pattern0 + board[68];
-  pattern0 = 3 * pattern0 + board[58];
-  pattern0 = 3 * pattern0 + board[48];
-  pattern0 = 3 * pattern0 + board[38];
-  pattern0 = 3 * pattern0 + board[28];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].afile2x[pattern0] );
-#endif
-  score += set[eval_phase].afile2x[pattern0];
-  pattern0 = board[27];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[18];
-  pattern0 = 3 * pattern0 + board[17];
-  pattern0 = 3 * pattern0 + board[16];
-  pattern0 = 3 * pattern0 + board[15];
-  pattern0 = 3 * pattern0 + board[14];
-  pattern0 = 3 * pattern0 + board[13];
-  pattern0 = 3 * pattern0 + board[12];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].afile2x[pattern0] );
-#endif
-  score += set[eval_phase].afile2x[pattern0];
-  pattern0 = board[77];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[88];
-  pattern0 = 3 * pattern0 + board[87];
-  pattern0 = 3 * pattern0 + board[86];
-  pattern0 = 3 * pattern0 + board[85];
-  pattern0 = 3 * pattern0 + board[84];
-  pattern0 = 3 * pattern0 + board[83];
-  pattern0 = 3 * pattern0 + board[82];
-  pattern0 = 3 * pattern0 + board[81];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].afile2x[pattern0] );
-#endif
-  score += set[eval_phase].afile2x[pattern0];
-  pattern0 = board[82];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[12];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].bfile[pattern0] );
-#endif
-  score += set[eval_phase].bfile[pattern0];
-  pattern0 = board[87];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[17];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].bfile[pattern0] );
-#endif
-  score += set[eval_phase].bfile[pattern0];
-  pattern0 = board[28];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[21];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].bfile[pattern0] );
-#endif
-  score += set[eval_phase].bfile[pattern0];
-  pattern0 = board[78];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[71];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].bfile[pattern0] );
-#endif
-  score += set[eval_phase].bfile[pattern0];
-  pattern0 = board[83];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[63];
-  pattern0 = 3 * pattern0 + board[53];
-  pattern0 = 3 * pattern0 + board[43];
-  pattern0 = 3 * pattern0 + board[33];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[13];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].cfile[pattern0] );
-#endif
-  score += set[eval_phase].cfile[pattern0];
-  pattern0 = board[86];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[66];
-  pattern0 = 3 * pattern0 + board[56];
-  pattern0 = 3 * pattern0 + board[46];
-  pattern0 = 3 * pattern0 + board[36];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[16];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].cfile[pattern0] );
-#endif
-  score += set[eval_phase].cfile[pattern0];
-  pattern0 = board[38];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[36];
-  pattern0 = 3 * pattern0 + board[35];
-  pattern0 = 3 * pattern0 + board[34];
-  pattern0 = 3 * pattern0 + board[33];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[31];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].cfile[pattern0] );
-#endif
-  score += set[eval_phase].cfile[pattern0];
-  pattern0 = board[68];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[66];
-  pattern0 = 3 * pattern0 + board[65];
-  pattern0 = 3 * pattern0 + board[64];
-  pattern0 = 3 * pattern0 + board[63];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[61];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].cfile[pattern0] );
-#endif
-  score += set[eval_phase].cfile[pattern0];
-  pattern0 = board[84];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[64];
-  pattern0 = 3 * pattern0 + board[54];
-  pattern0 = 3 * pattern0 + board[44];
-  pattern0 = 3 * pattern0 + board[34];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[14];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].dfile[pattern0] );
-#endif
-  score += set[eval_phase].dfile[pattern0];
-  pattern0 = board[85];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[65];
-  pattern0 = 3 * pattern0 + board[55];
-  pattern0 = 3 * pattern0 + board[45];
-  pattern0 = 3 * pattern0 + board[35];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[15];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].dfile[pattern0] );
-#endif
-  score += set[eval_phase].dfile[pattern0];
-  pattern0 = board[48];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[46];
-  pattern0 = 3 * pattern0 + board[45];
-  pattern0 = 3 * pattern0 + board[44];
-  pattern0 = 3 * pattern0 + board[43];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[41];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].dfile[pattern0] );
-#endif
-  score += set[eval_phase].dfile[pattern0];
-  pattern0 = board[58];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[56];
-  pattern0 = 3 * pattern0 + board[55];
-  pattern0 = 3 * pattern0 + board[54];
-  pattern0 = 3 * pattern0 + board[53];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[51];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].dfile[pattern0] );
-#endif
-  score += set[eval_phase].dfile[pattern0];
-  pattern0 = board[88];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[66];
-  pattern0 = 3 * pattern0 + board[55];
-  pattern0 = 3 * pattern0 + board[44];
-  pattern0 = 3 * pattern0 + board[33];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag8[pattern0] );
-#endif
-  score += set[eval_phase].diag8[pattern0];
-  pattern0 = board[81];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[63];
-  pattern0 = 3 * pattern0 + board[54];
-  pattern0 = 3 * pattern0 + board[45];
-  pattern0 = 3 * pattern0 + board[36];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag8[pattern0] );
-#endif
-  score += set[eval_phase].diag8[pattern0];
-  pattern0 = board[78];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[56];
-  pattern0 = 3 * pattern0 + board[45];
-  pattern0 = 3 * pattern0 + board[34];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[12];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag7[pattern0] );
-#endif
-  score += set[eval_phase].diag7[pattern0];
-  pattern0 = board[87];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[65];
-  pattern0 = 3 * pattern0 + board[54];
-  pattern0 = 3 * pattern0 + board[43];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[21];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag7[pattern0] );
-#endif
-  score += set[eval_phase].diag7[pattern0];
-  pattern0 = board[71];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[53];
-  pattern0 = 3 * pattern0 + board[44];
-  pattern0 = 3 * pattern0 + board[35];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[17];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag7[pattern0] );
-#endif
-  score += set[eval_phase].diag7[pattern0];
-  pattern0 = board[82];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[64];
-  pattern0 = 3 * pattern0 + board[55];
-  pattern0 = 3 * pattern0 + board[46];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[28];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag7[pattern0] );
-#endif
-  score += set[eval_phase].diag7[pattern0];
-  pattern0 = board[68];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[46];
-  pattern0 = 3 * pattern0 + board[35];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[13];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag6[pattern0] );
-#endif
-  score += set[eval_phase].diag6[pattern0];
-  pattern0 = board[86];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[64];
-  pattern0 = 3 * pattern0 + board[53];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[31];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag6[pattern0] );
-#endif
-  score += set[eval_phase].diag6[pattern0];
-  pattern0 = board[61];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[43];
-  pattern0 = 3 * pattern0 + board[34];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[16];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag6[pattern0] );
-#endif
-  score += set[eval_phase].diag6[pattern0];
-  pattern0 = board[83];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[65];
-  pattern0 = 3 * pattern0 + board[56];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[38];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag6[pattern0] );
-#endif
-  score += set[eval_phase].diag6[pattern0];
-  pattern0 = board[58];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[36];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[14];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag5[pattern0] );
-#endif
-  score += set[eval_phase].diag5[pattern0];
-  pattern0 = board[85];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[63];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[41];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag5[pattern0] );
-#endif
-  score += set[eval_phase].diag5[pattern0];
-  pattern0 = board[51];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[33];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[15];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag5[pattern0] );
-#endif
-  score += set[eval_phase].diag5[pattern0];
-  pattern0 = board[84];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[66];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[48];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag5[pattern0] );
-#endif
-  score += set[eval_phase].diag5[pattern0];
-  pattern0 = board[48];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[15];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag4[pattern0] );
-#endif
-  score += set[eval_phase].diag4[pattern0];
-  pattern0 = board[84];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[51];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag4[pattern0] );
-#endif
-  score += set[eval_phase].diag4[pattern0];
-  pattern0 = board[41];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[14];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag4[pattern0] );
-#endif
-  score += set[eval_phase].diag4[pattern0];
-  pattern0 = board[85];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[58];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag4[pattern0] );
-#endif
-  score += set[eval_phase].diag4[pattern0];
-  pattern0 = board[33];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[31];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[21];
-  pattern0 = 3 * pattern0 + board[13];
-  pattern0 = 3 * pattern0 + board[12];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner33[pattern0] );
-#endif
-  score += set[eval_phase].corner33[pattern0];
-  pattern0 = board[63];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[61];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[71];
-  pattern0 = 3 * pattern0 + board[83];
-  pattern0 = 3 * pattern0 + board[82];
-  pattern0 = 3 * pattern0 + board[81];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner33[pattern0] );
-#endif
-  score += set[eval_phase].corner33[pattern0];
-  pattern0 = board[36];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[38];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[28];
-  pattern0 = 3 * pattern0 + board[16];
-  pattern0 = 3 * pattern0 + board[17];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner33[pattern0] );
-#endif
-  score += set[eval_phase].corner33[pattern0];
-  pattern0 = board[66];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[68];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[78];
-  pattern0 = 3 * pattern0 + board[86];
-  pattern0 = 3 * pattern0 + board[87];
-  pattern0 = 3 * pattern0 + board[88];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner33[pattern0] );
-#endif
-  score += set[eval_phase].corner33[pattern0];
-  pattern0 = board[25];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[21];
-  pattern0 = 3 * pattern0 + board[15];
-  pattern0 = 3 * pattern0 + board[14];
-  pattern0 = 3 * pattern0 + board[13];
-  pattern0 = 3 * pattern0 + board[12];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52[pattern0] );
-#endif
-  score += set[eval_phase].corner52[pattern0];
-  pattern0 = board[75];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[71];
-  pattern0 = 3 * pattern0 + board[85];
-  pattern0 = 3 * pattern0 + board[84];
-  pattern0 = 3 * pattern0 + board[83];
-  pattern0 = 3 * pattern0 + board[82];
-  pattern0 = 3 * pattern0 + board[81];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52[pattern0] );
-#endif
-  score += set[eval_phase].corner52[pattern0];
-  pattern0 = board[24];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[28];
-  pattern0 = 3 * pattern0 + board[14];
-  pattern0 = 3 * pattern0 + board[15];
-  pattern0 = 3 * pattern0 + board[16];
-  pattern0 = 3 * pattern0 + board[17];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52[pattern0] );
-#endif
-  score += set[eval_phase].corner52[pattern0];
-  pattern0 = board[74];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[78];
-  pattern0 = 3 * pattern0 + board[84];
-  pattern0 = 3 * pattern0 + board[85];
-  pattern0 = 3 * pattern0 + board[86];
-  pattern0 = 3 * pattern0 + board[87];
-  pattern0 = 3 * pattern0 + board[88];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52[pattern0] );
-#endif
-  score += set[eval_phase].corner52[pattern0];
-  pattern0 = board[52];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[12];
-  pattern0 = 3 * pattern0 + board[51];
-  pattern0 = 3 * pattern0 + board[41];
-  pattern0 = 3 * pattern0 + board[31];
-  pattern0 = 3 * pattern0 + board[21];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52[pattern0] );
-#endif
-  score += set[eval_phase].corner52[pattern0];
-  pattern0 = board[57];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[17];
-  pattern0 = 3 * pattern0 + board[58];
-  pattern0 = 3 * pattern0 + board[48];
-  pattern0 = 3 * pattern0 + board[38];
-  pattern0 = 3 * pattern0 + board[28];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52[pattern0] );
-#endif
-  score += set[eval_phase].corner52[pattern0];
-  pattern0 = board[42];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[82];
-  pattern0 = 3 * pattern0 + board[41];
-  pattern0 = 3 * pattern0 + board[51];
-  pattern0 = 3 * pattern0 + board[61];
-  pattern0 = 3 * pattern0 + board[71];
-  pattern0 = 3 * pattern0 + board[81];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52[pattern0] );
-#endif
-  score += set[eval_phase].corner52[pattern0];
-  pattern0 = board[47];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[87];
-  pattern0 = 3 * pattern0 + board[48];
-  pattern0 = 3 * pattern0 + board[58];
-  pattern0 = 3 * pattern0 + board[68];
-  pattern0 = 3 * pattern0 + board[78];
-  pattern0 = 3 * pattern0 + board[88];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52[pattern0] );
-#endif
-  score += set[eval_phase].corner52[pattern0];
-#endif
-  }
-  else {
-#ifdef USE_PENTIUM_ASM
-    int pattern0;
-    int pattern1;
-    int pattern2;
-    int pattern3;
-    asm( 
-         "movl _board+288,%0\n\t"
-         "movl _board+308,%1\n\t"
-         "movl _board+108,%2\n\t"
-         "movl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+108,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+88,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+288,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+324,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+352,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+72,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+352,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+284,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+312,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+68,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+348,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+244,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+272,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+64,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+344,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+204,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+232,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+60,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+340,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+164,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+192,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+56,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+336,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+124,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+152,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+52,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+332,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+84,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+112,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+48,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+328,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+72,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+44,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+324,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].afile2x_last[-pattern0];
-    score += set[eval_phase].afile2x_last[-pattern1];
-    score += set[eval_phase].afile2x_last[-pattern2];
-    score += set[eval_phase].afile2x_last[-pattern3];
-    asm( 
-         "movl _board+328,%0\n\t"
-         "movl _board+348,%1\n\t"
-         "movl _board+112,%2\n\t"
-         "movl _board+312,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+288,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+308,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+108,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+248,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+268,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+104,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+304,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+208,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+228,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+100,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+300,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+168,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+188,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+96,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+296,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+128,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+148,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+92,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+292,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+108,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+88,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+288,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+68,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+84,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+284,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].bfile_last[-pattern0];
-    score += set[eval_phase].bfile_last[-pattern1];
-    score += set[eval_phase].bfile_last[-pattern2];
-    score += set[eval_phase].bfile_last[-pattern3];
-    asm( 
-         "movl _board+332,%0\n\t"
-         "movl _board+344,%1\n\t"
-         "movl _board+152,%2\n\t"
-         "movl _board+272,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+292,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+304,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+148,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+268,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+252,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+264,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+144,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+264,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+212,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+224,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+140,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+260,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+172,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+184,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+136,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+256,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+132,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+144,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+132,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+252,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+92,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+104,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+128,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+248,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+52,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+64,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+124,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+244,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].cfile_last[-pattern0];
-    score += set[eval_phase].cfile_last[-pattern1];
-    score += set[eval_phase].cfile_last[-pattern2];
-    score += set[eval_phase].cfile_last[-pattern3];
-    asm( 
-         "movl _board+336,%0\n\t"
-         "movl _board+340,%1\n\t"
-         "movl _board+192,%2\n\t"
-         "movl _board+232,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+296,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+300,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+188,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+228,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+256,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+260,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+184,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+224,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+216,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+220,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+180,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+220,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+176,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+180,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+176,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+216,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+136,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+140,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+172,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+212,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+96,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+100,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+168,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+208,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+56,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+60,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+164,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+204,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].dfile_last[-pattern0];
-    score += set[eval_phase].dfile_last[-pattern1];
-    score += set[eval_phase].dfile_last[-pattern2];
-    score += set[eval_phase].dfile_last[-pattern3];
-    asm( 
-         "movl _board+352,%0\n\t"
-         "movl _board+324,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+308,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+288,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+264,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+252,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+220,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+216,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+176,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+180,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+132,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+144,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+108,%1\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+72,%1"
-         : "=r" (pattern0), "=r" (pattern1) : );
-    score += set[eval_phase].diag8_last[-pattern0];
-    score += set[eval_phase].diag8_last[-pattern1];
-    asm( 
-         "movl _board+312,%0\n\t"
-         "movl _board+348,%1\n\t"
-         "movl _board+284,%2\n\t"
-         "movl _board+328,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+268,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+304,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+248,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+292,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+224,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+260,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+212,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+256,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+180,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+216,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+176,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+220,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+136,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+172,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+140,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+184,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+92,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+128,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+104,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+148,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+84,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+68,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+112,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].diag7_last[-pattern0];
-    score += set[eval_phase].diag7_last[-pattern1];
-    score += set[eval_phase].diag7_last[-pattern2];
-    score += set[eval_phase].diag7_last[-pattern3];
-    asm( 
-         "movl _board+272,%0\n\t"
-         "movl _board+344,%1\n\t"
-         "movl _board+244,%2\n\t"
-         "movl _board+332,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+228,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+300,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+208,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+296,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+184,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+256,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+172,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+260,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+140,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+212,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+136,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+224,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+96,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+168,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+100,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+188,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+52,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+124,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+64,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+152,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].diag6_last[-pattern0];
-    score += set[eval_phase].diag6_last[-pattern1];
-    score += set[eval_phase].diag6_last[-pattern2];
-    score += set[eval_phase].diag6_last[-pattern3];
-    asm( 
-         "movl _board+232,%0\n\t"
-         "movl _board+340,%1\n\t"
-         "movl _board+204,%2\n\t"
-         "movl _board+336,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+188,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+296,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+168,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+300,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+144,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+252,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+132,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+264,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+100,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+208,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+96,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+228,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+56,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+164,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+60,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+192,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].diag5_last[-pattern0];
-    score += set[eval_phase].diag5_last[-pattern1];
-    score += set[eval_phase].diag5_last[-pattern2];
-    score += set[eval_phase].diag5_last[-pattern3];
-    asm( 
-         "movl _board+192,%0\n\t"
-         "movl _board+336,%1\n\t"
-         "movl _board+164,%2\n\t"
-         "movl _board+340,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+148,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+292,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+128,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+304,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+104,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+248,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+92,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+268,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+60,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+204,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+56,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+232,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].diag4_last[-pattern0];
-    score += set[eval_phase].diag4_last[-pattern1];
-    score += set[eval_phase].diag4_last[-pattern2];
-    score += set[eval_phase].diag4_last[-pattern3];
-    asm( 
-         "movl _board+132,%0\n\t"
-         "movl _board+252,%1\n\t"
-         "movl _board+144,%2\n\t"
-         "movl _board+264,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+128,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+248,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+148,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+268,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+124,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+244,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+152,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+272,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+92,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+292,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+104,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+304,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+288,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+108,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+84,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+284,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+112,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+312,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+52,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+332,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+64,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+344,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+328,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+68,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+348,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+324,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+72,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+352,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].corner33_last[-pattern0];
-    score += set[eval_phase].corner33_last[-pattern1];
-    score += set[eval_phase].corner33_last[-pattern2];
-    score += set[eval_phase].corner33_last[-pattern3];
-    asm( 
-         "movl _board+100,%0\n\t"
-         "movl _board+300,%1\n\t"
-         "movl _board+96,%2\n\t"
-         "movl _board+296,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+96,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+296,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+100,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+300,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+92,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+292,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+104,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+304,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+288,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+108,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+84,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+284,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+112,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+312,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+60,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+340,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+56,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+336,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+56,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+336,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+60,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+340,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+52,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+332,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+64,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+344,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+328,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+68,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+348,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+324,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+72,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+352,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].corner52_last[-pattern0];
-    score += set[eval_phase].corner52_last[-pattern1];
-    score += set[eval_phase].corner52_last[-pattern2];
-    score += set[eval_phase].corner52_last[-pattern3];
-    asm( 
-         "movl _board+208,%0\n\t"
-         "movl _board+228,%1\n\t"
-         "movl _board+168,%2\n\t"
-         "movl _board+188,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+168,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+188,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+208,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+228,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+128,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+148,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+248,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+268,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+88,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+108,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+288,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+308,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+48,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+68,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+328,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+348,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+204,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+232,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+164,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+192,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+164,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+192,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+204,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+232,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+124,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+152,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+244,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+272,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+84,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+112,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+284,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+312,%3\n\t"
-         "leal (%0,%0,2),%0\n\t"
-         "addl _board+44,%0\n\t"
-         "leal (%1,%1,2),%1\n\t"
-         "addl _board+72,%1\n\t"
-         "leal (%2,%2,2),%2\n\t"
-         "addl _board+324,%2\n\t"
-         "leal (%3,%3,2),%3\n\t"
-         "addl _board+352,%3"
-         : "=r" (pattern0), "=r" (pattern1), "=r" (pattern2), "=r" (pattern3) : );
-    score += set[eval_phase].corner52_last[-pattern0];
-    score += set[eval_phase].corner52_last[-pattern1];
-    score += set[eval_phase].corner52_last[-pattern2];
-    score += set[eval_phase].corner52_last[-pattern3];
-#else
-  int pattern0;
-  pattern0 = board[72];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[81];
-  pattern0 = 3 * pattern0 + board[71];
-  pattern0 = 3 * pattern0 + board[61];
-  pattern0 = 3 * pattern0 + board[51];
-  pattern0 = 3 * pattern0 + board[41];
-  pattern0 = 3 * pattern0 + board[31];
-  pattern0 = 3 * pattern0 + board[21];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].afile2x_last[-pattern0] );
-#endif
-  score += set[eval_phase].afile2x_last[-pattern0];
-  pattern0 = board[77];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[88];
-  pattern0 = 3 * pattern0 + board[78];
-  pattern0 = 3 * pattern0 + board[68];
-  pattern0 = 3 * pattern0 + board[58];
-  pattern0 = 3 * pattern0 + board[48];
-  pattern0 = 3 * pattern0 + board[38];
-  pattern0 = 3 * pattern0 + board[28];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].afile2x_last[-pattern0] );
-#endif
-  score += set[eval_phase].afile2x_last[-pattern0];
-  pattern0 = board[27];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[18];
-  pattern0 = 3 * pattern0 + board[17];
-  pattern0 = 3 * pattern0 + board[16];
-  pattern0 = 3 * pattern0 + board[15];
-  pattern0 = 3 * pattern0 + board[14];
-  pattern0 = 3 * pattern0 + board[13];
-  pattern0 = 3 * pattern0 + board[12];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].afile2x_last[-pattern0] );
-#endif
-  score += set[eval_phase].afile2x_last[-pattern0];
-  pattern0 = board[77];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[88];
-  pattern0 = 3 * pattern0 + board[87];
-  pattern0 = 3 * pattern0 + board[86];
-  pattern0 = 3 * pattern0 + board[85];
-  pattern0 = 3 * pattern0 + board[84];
-  pattern0 = 3 * pattern0 + board[83];
-  pattern0 = 3 * pattern0 + board[82];
-  pattern0 = 3 * pattern0 + board[81];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].afile2x_last[-pattern0] );
-#endif
-  score += set[eval_phase].afile2x_last[-pattern0];
-  pattern0 = board[82];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[12];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].bfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].bfile_last[-pattern0];
-  pattern0 = board[87];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[17];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].bfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].bfile_last[-pattern0];
-  pattern0 = board[28];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[21];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].bfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].bfile_last[-pattern0];
-  pattern0 = board[78];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[71];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].bfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].bfile_last[-pattern0];
-  pattern0 = board[83];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[63];
-  pattern0 = 3 * pattern0 + board[53];
-  pattern0 = 3 * pattern0 + board[43];
-  pattern0 = 3 * pattern0 + board[33];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[13];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].cfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].cfile_last[-pattern0];
-  pattern0 = board[86];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[66];
-  pattern0 = 3 * pattern0 + board[56];
-  pattern0 = 3 * pattern0 + board[46];
-  pattern0 = 3 * pattern0 + board[36];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[16];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].cfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].cfile_last[-pattern0];
-  pattern0 = board[38];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[36];
-  pattern0 = 3 * pattern0 + board[35];
-  pattern0 = 3 * pattern0 + board[34];
-  pattern0 = 3 * pattern0 + board[33];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[31];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].cfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].cfile_last[-pattern0];
-  pattern0 = board[68];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[66];
-  pattern0 = 3 * pattern0 + board[65];
-  pattern0 = 3 * pattern0 + board[64];
-  pattern0 = 3 * pattern0 + board[63];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[61];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].cfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].cfile_last[-pattern0];
-  pattern0 = board[84];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[64];
-  pattern0 = 3 * pattern0 + board[54];
-  pattern0 = 3 * pattern0 + board[44];
-  pattern0 = 3 * pattern0 + board[34];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[14];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].dfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].dfile_last[-pattern0];
-  pattern0 = board[85];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[65];
-  pattern0 = 3 * pattern0 + board[55];
-  pattern0 = 3 * pattern0 + board[45];
-  pattern0 = 3 * pattern0 + board[35];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[15];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].dfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].dfile_last[-pattern0];
-  pattern0 = board[48];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[46];
-  pattern0 = 3 * pattern0 + board[45];
-  pattern0 = 3 * pattern0 + board[44];
-  pattern0 = 3 * pattern0 + board[43];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[41];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].dfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].dfile_last[-pattern0];
-  pattern0 = board[58];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[56];
-  pattern0 = 3 * pattern0 + board[55];
-  pattern0 = 3 * pattern0 + board[54];
-  pattern0 = 3 * pattern0 + board[53];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[51];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].dfile_last[-pattern0] );
-#endif
-  score += set[eval_phase].dfile_last[-pattern0];
-  pattern0 = board[88];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[66];
-  pattern0 = 3 * pattern0 + board[55];
-  pattern0 = 3 * pattern0 + board[44];
-  pattern0 = 3 * pattern0 + board[33];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag8_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag8_last[-pattern0];
-  pattern0 = board[81];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[63];
-  pattern0 = 3 * pattern0 + board[54];
-  pattern0 = 3 * pattern0 + board[45];
-  pattern0 = 3 * pattern0 + board[36];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag8_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag8_last[-pattern0];
-  pattern0 = board[78];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[56];
-  pattern0 = 3 * pattern0 + board[45];
-  pattern0 = 3 * pattern0 + board[34];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[12];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag7_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag7_last[-pattern0];
-  pattern0 = board[87];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[65];
-  pattern0 = 3 * pattern0 + board[54];
-  pattern0 = 3 * pattern0 + board[43];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[21];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag7_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag7_last[-pattern0];
-  pattern0 = board[71];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[53];
-  pattern0 = 3 * pattern0 + board[44];
-  pattern0 = 3 * pattern0 + board[35];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[17];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag7_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag7_last[-pattern0];
-  pattern0 = board[82];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[64];
-  pattern0 = 3 * pattern0 + board[55];
-  pattern0 = 3 * pattern0 + board[46];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[28];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag7_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag7_last[-pattern0];
-  pattern0 = board[68];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[46];
-  pattern0 = 3 * pattern0 + board[35];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[13];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag6_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag6_last[-pattern0];
-  pattern0 = board[86];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[64];
-  pattern0 = 3 * pattern0 + board[53];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[31];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag6_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag6_last[-pattern0];
-  pattern0 = board[61];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[43];
-  pattern0 = 3 * pattern0 + board[34];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[16];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag6_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag6_last[-pattern0];
-  pattern0 = board[83];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[65];
-  pattern0 = 3 * pattern0 + board[56];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[38];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag6_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag6_last[-pattern0];
-  pattern0 = board[58];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[36];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[14];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag5_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag5_last[-pattern0];
-  pattern0 = board[85];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[63];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[41];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag5_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag5_last[-pattern0];
-  pattern0 = board[51];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[33];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[15];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag5_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag5_last[-pattern0];
-  pattern0 = board[84];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[66];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[48];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag5_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag5_last[-pattern0];
-  pattern0 = board[48];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[15];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag4_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag4_last[-pattern0];
-  pattern0 = board[84];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[51];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag4_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag4_last[-pattern0];
-  pattern0 = board[41];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[14];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag4_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag4_last[-pattern0];
-  pattern0 = board[85];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[58];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].diag4_last[-pattern0] );
-#endif
-  score += set[eval_phase].diag4_last[-pattern0];
-  pattern0 = board[33];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[31];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[21];
-  pattern0 = 3 * pattern0 + board[13];
-  pattern0 = 3 * pattern0 + board[12];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner33_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner33_last[-pattern0];
-  pattern0 = board[63];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[61];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[71];
-  pattern0 = 3 * pattern0 + board[83];
-  pattern0 = 3 * pattern0 + board[82];
-  pattern0 = 3 * pattern0 + board[81];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner33_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner33_last[-pattern0];
-  pattern0 = board[36];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[38];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[28];
-  pattern0 = 3 * pattern0 + board[16];
-  pattern0 = 3 * pattern0 + board[17];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner33_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner33_last[-pattern0];
-  pattern0 = board[66];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[68];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[78];
-  pattern0 = 3 * pattern0 + board[86];
-  pattern0 = 3 * pattern0 + board[87];
-  pattern0 = 3 * pattern0 + board[88];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner33_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner33_last[-pattern0];
-  pattern0 = board[25];
-  pattern0 = 3 * pattern0 + board[24];
-  pattern0 = 3 * pattern0 + board[23];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[21];
-  pattern0 = 3 * pattern0 + board[15];
-  pattern0 = 3 * pattern0 + board[14];
-  pattern0 = 3 * pattern0 + board[13];
-  pattern0 = 3 * pattern0 + board[12];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner52_last[-pattern0];
-  pattern0 = board[75];
-  pattern0 = 3 * pattern0 + board[74];
-  pattern0 = 3 * pattern0 + board[73];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[71];
-  pattern0 = 3 * pattern0 + board[85];
-  pattern0 = 3 * pattern0 + board[84];
-  pattern0 = 3 * pattern0 + board[83];
-  pattern0 = 3 * pattern0 + board[82];
-  pattern0 = 3 * pattern0 + board[81];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner52_last[-pattern0];
-  pattern0 = board[24];
-  pattern0 = 3 * pattern0 + board[25];
-  pattern0 = 3 * pattern0 + board[26];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[28];
-  pattern0 = 3 * pattern0 + board[14];
-  pattern0 = 3 * pattern0 + board[15];
-  pattern0 = 3 * pattern0 + board[16];
-  pattern0 = 3 * pattern0 + board[17];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner52_last[-pattern0];
-  pattern0 = board[74];
-  pattern0 = 3 * pattern0 + board[75];
-  pattern0 = 3 * pattern0 + board[76];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[78];
-  pattern0 = 3 * pattern0 + board[84];
-  pattern0 = 3 * pattern0 + board[85];
-  pattern0 = 3 * pattern0 + board[86];
-  pattern0 = 3 * pattern0 + board[87];
-  pattern0 = 3 * pattern0 + board[88];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner52_last[-pattern0];
-  pattern0 = board[52];
-  pattern0 = 3 * pattern0 + board[42];
-  pattern0 = 3 * pattern0 + board[32];
-  pattern0 = 3 * pattern0 + board[22];
-  pattern0 = 3 * pattern0 + board[12];
-  pattern0 = 3 * pattern0 + board[51];
-  pattern0 = 3 * pattern0 + board[41];
-  pattern0 = 3 * pattern0 + board[31];
-  pattern0 = 3 * pattern0 + board[21];
-  pattern0 = 3 * pattern0 + board[11];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner52_last[-pattern0];
-  pattern0 = board[57];
-  pattern0 = 3 * pattern0 + board[47];
-  pattern0 = 3 * pattern0 + board[37];
-  pattern0 = 3 * pattern0 + board[27];
-  pattern0 = 3 * pattern0 + board[17];
-  pattern0 = 3 * pattern0 + board[58];
-  pattern0 = 3 * pattern0 + board[48];
-  pattern0 = 3 * pattern0 + board[38];
-  pattern0 = 3 * pattern0 + board[28];
-  pattern0 = 3 * pattern0 + board[18];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner52_last[-pattern0];
-  pattern0 = board[42];
-  pattern0 = 3 * pattern0 + board[52];
-  pattern0 = 3 * pattern0 + board[62];
-  pattern0 = 3 * pattern0 + board[72];
-  pattern0 = 3 * pattern0 + board[82];
-  pattern0 = 3 * pattern0 + board[41];
-  pattern0 = 3 * pattern0 + board[51];
-  pattern0 = 3 * pattern0 + board[61];
-  pattern0 = 3 * pattern0 + board[71];
-  pattern0 = 3 * pattern0 + board[81];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner52_last[-pattern0];
-  pattern0 = board[47];
-  pattern0 = 3 * pattern0 + board[57];
-  pattern0 = 3 * pattern0 + board[67];
-  pattern0 = 3 * pattern0 + board[77];
-  pattern0 = 3 * pattern0 + board[87];
-  pattern0 = 3 * pattern0 + board[48];
-  pattern0 = 3 * pattern0 + board[58];
-  pattern0 = 3 * pattern0 + board[68];
-  pattern0 = 3 * pattern0 + board[78];
-  pattern0 = 3 * pattern0 + board[88];
-#ifdef LOG_EVAL
-  fprintf( stream, "pattern=%d\n", pattern0 );
-  fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pattern0] );
-#endif
-  score += set[eval_phase].corner52_last[-pattern0];
+  /* The pattern indices are maintained incrementally by
+     MAKE_MOVE and UNMAKE_MOVE; see update_pattern_indices().
+     They are kept in black perspective, so the white-to-move
+     lookup reads the tables backwards, as it always has. */
+
+#if VERIFY_INCREMENTAL_EVAL
+  verify_pattern_indices();
 #endif
+
+  {
+    const unsigned short *pi = eval_pattern_index;
+
+    if ( side_to_move == BLACKSQ ) {
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[0] );
+      fprintf( stream, "score=%d\n", set[eval_phase].afile2x[pi[0]] );
+#endif
+      score += set[eval_phase].afile2x[pi[0]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[1] );
+      fprintf( stream, "score=%d\n", set[eval_phase].afile2x[pi[1]] );
+#endif
+      score += set[eval_phase].afile2x[pi[1]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[2] );
+      fprintf( stream, "score=%d\n", set[eval_phase].afile2x[pi[2]] );
+#endif
+      score += set[eval_phase].afile2x[pi[2]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[3] );
+      fprintf( stream, "score=%d\n", set[eval_phase].afile2x[pi[3]] );
+#endif
+      score += set[eval_phase].afile2x[pi[3]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[4] );
+      fprintf( stream, "score=%d\n", set[eval_phase].bfile[pi[4]] );
+#endif
+      score += set[eval_phase].bfile[pi[4]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[5] );
+      fprintf( stream, "score=%d\n", set[eval_phase].bfile[pi[5]] );
+#endif
+      score += set[eval_phase].bfile[pi[5]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[6] );
+      fprintf( stream, "score=%d\n", set[eval_phase].bfile[pi[6]] );
+#endif
+      score += set[eval_phase].bfile[pi[6]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[7] );
+      fprintf( stream, "score=%d\n", set[eval_phase].bfile[pi[7]] );
+#endif
+      score += set[eval_phase].bfile[pi[7]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[8] );
+      fprintf( stream, "score=%d\n", set[eval_phase].cfile[pi[8]] );
+#endif
+      score += set[eval_phase].cfile[pi[8]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[9] );
+      fprintf( stream, "score=%d\n", set[eval_phase].cfile[pi[9]] );
+#endif
+      score += set[eval_phase].cfile[pi[9]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[10] );
+      fprintf( stream, "score=%d\n", set[eval_phase].cfile[pi[10]] );
+#endif
+      score += set[eval_phase].cfile[pi[10]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[11] );
+      fprintf( stream, "score=%d\n", set[eval_phase].cfile[pi[11]] );
+#endif
+      score += set[eval_phase].cfile[pi[11]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[12] );
+      fprintf( stream, "score=%d\n", set[eval_phase].dfile[pi[12]] );
+#endif
+      score += set[eval_phase].dfile[pi[12]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[13] );
+      fprintf( stream, "score=%d\n", set[eval_phase].dfile[pi[13]] );
+#endif
+      score += set[eval_phase].dfile[pi[13]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[14] );
+      fprintf( stream, "score=%d\n", set[eval_phase].dfile[pi[14]] );
+#endif
+      score += set[eval_phase].dfile[pi[14]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[15] );
+      fprintf( stream, "score=%d\n", set[eval_phase].dfile[pi[15]] );
+#endif
+      score += set[eval_phase].dfile[pi[15]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[16] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag8[pi[16]] );
+#endif
+      score += set[eval_phase].diag8[pi[16]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[17] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag8[pi[17]] );
+#endif
+      score += set[eval_phase].diag8[pi[17]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[18] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag7[pi[18]] );
+#endif
+      score += set[eval_phase].diag7[pi[18]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[19] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag7[pi[19]] );
+#endif
+      score += set[eval_phase].diag7[pi[19]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[20] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag7[pi[20]] );
+#endif
+      score += set[eval_phase].diag7[pi[20]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[21] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag7[pi[21]] );
+#endif
+      score += set[eval_phase].diag7[pi[21]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[22] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag6[pi[22]] );
+#endif
+      score += set[eval_phase].diag6[pi[22]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[23] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag6[pi[23]] );
+#endif
+      score += set[eval_phase].diag6[pi[23]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[24] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag6[pi[24]] );
+#endif
+      score += set[eval_phase].diag6[pi[24]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[25] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag6[pi[25]] );
+#endif
+      score += set[eval_phase].diag6[pi[25]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[26] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag5[pi[26]] );
+#endif
+      score += set[eval_phase].diag5[pi[26]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[27] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag5[pi[27]] );
+#endif
+      score += set[eval_phase].diag5[pi[27]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[28] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag5[pi[28]] );
+#endif
+      score += set[eval_phase].diag5[pi[28]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[29] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag5[pi[29]] );
+#endif
+      score += set[eval_phase].diag5[pi[29]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[30] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag4[pi[30]] );
+#endif
+      score += set[eval_phase].diag4[pi[30]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[31] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag4[pi[31]] );
+#endif
+      score += set[eval_phase].diag4[pi[31]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[32] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag4[pi[32]] );
+#endif
+      score += set[eval_phase].diag4[pi[32]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[33] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag4[pi[33]] );
+#endif
+      score += set[eval_phase].diag4[pi[33]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[34] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner33[pi[34]] );
+#endif
+      score += set[eval_phase].corner33[pi[34]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[35] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner33[pi[35]] );
+#endif
+      score += set[eval_phase].corner33[pi[35]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[36] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner33[pi[36]] );
+#endif
+      score += set[eval_phase].corner33[pi[36]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[37] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner33[pi[37]] );
+#endif
+      score += set[eval_phase].corner33[pi[37]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[38] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52[pi[38]] );
+#endif
+      score += set[eval_phase].corner52[pi[38]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[39] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52[pi[39]] );
+#endif
+      score += set[eval_phase].corner52[pi[39]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[40] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52[pi[40]] );
+#endif
+      score += set[eval_phase].corner52[pi[40]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[41] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52[pi[41]] );
+#endif
+      score += set[eval_phase].corner52[pi[41]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[42] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52[pi[42]] );
+#endif
+      score += set[eval_phase].corner52[pi[42]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[43] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52[pi[43]] );
+#endif
+      score += set[eval_phase].corner52[pi[43]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[44] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52[pi[44]] );
+#endif
+      score += set[eval_phase].corner52[pi[44]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[45] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52[pi[45]] );
+#endif
+      score += set[eval_phase].corner52[pi[45]];
+    }
+    else {
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[0] );
+      fprintf( stream, "score=%d\n", set[eval_phase].afile2x_last[-pi[0]] );
+#endif
+      score += set[eval_phase].afile2x_last[-pi[0]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[1] );
+      fprintf( stream, "score=%d\n", set[eval_phase].afile2x_last[-pi[1]] );
+#endif
+      score += set[eval_phase].afile2x_last[-pi[1]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[2] );
+      fprintf( stream, "score=%d\n", set[eval_phase].afile2x_last[-pi[2]] );
+#endif
+      score += set[eval_phase].afile2x_last[-pi[2]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[3] );
+      fprintf( stream, "score=%d\n", set[eval_phase].afile2x_last[-pi[3]] );
+#endif
+      score += set[eval_phase].afile2x_last[-pi[3]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[4] );
+      fprintf( stream, "score=%d\n", set[eval_phase].bfile_last[-pi[4]] );
+#endif
+      score += set[eval_phase].bfile_last[-pi[4]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[5] );
+      fprintf( stream, "score=%d\n", set[eval_phase].bfile_last[-pi[5]] );
+#endif
+      score += set[eval_phase].bfile_last[-pi[5]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[6] );
+      fprintf( stream, "score=%d\n", set[eval_phase].bfile_last[-pi[6]] );
+#endif
+      score += set[eval_phase].bfile_last[-pi[6]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[7] );
+      fprintf( stream, "score=%d\n", set[eval_phase].bfile_last[-pi[7]] );
+#endif
+      score += set[eval_phase].bfile_last[-pi[7]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[8] );
+      fprintf( stream, "score=%d\n", set[eval_phase].cfile_last[-pi[8]] );
+#endif
+      score += set[eval_phase].cfile_last[-pi[8]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[9] );
+      fprintf( stream, "score=%d\n", set[eval_phase].cfile_last[-pi[9]] );
+#endif
+      score += set[eval_phase].cfile_last[-pi[9]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[10] );
+      fprintf( stream, "score=%d\n", set[eval_phase].cfile_last[-pi[10]] );
+#endif
+      score += set[eval_phase].cfile_last[-pi[10]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[11] );
+      fprintf( stream, "score=%d\n", set[eval_phase].cfile_last[-pi[11]] );
+#endif
+      score += set[eval_phase].cfile_last[-pi[11]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[12] );
+      fprintf( stream, "score=%d\n", set[eval_phase].dfile_last[-pi[12]] );
+#endif
+      score += set[eval_phase].dfile_last[-pi[12]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[13] );
+      fprintf( stream, "score=%d\n", set[eval_phase].dfile_last[-pi[13]] );
+#endif
+      score += set[eval_phase].dfile_last[-pi[13]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[14] );
+      fprintf( stream, "score=%d\n", set[eval_phase].dfile_last[-pi[14]] );
+#endif
+      score += set[eval_phase].dfile_last[-pi[14]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[15] );
+      fprintf( stream, "score=%d\n", set[eval_phase].dfile_last[-pi[15]] );
+#endif
+      score += set[eval_phase].dfile_last[-pi[15]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[16] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag8_last[-pi[16]] );
+#endif
+      score += set[eval_phase].diag8_last[-pi[16]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[17] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag8_last[-pi[17]] );
+#endif
+      score += set[eval_phase].diag8_last[-pi[17]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[18] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag7_last[-pi[18]] );
+#endif
+      score += set[eval_phase].diag7_last[-pi[18]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[19] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag7_last[-pi[19]] );
+#endif
+      score += set[eval_phase].diag7_last[-pi[19]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[20] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag7_last[-pi[20]] );
+#endif
+      score += set[eval_phase].diag7_last[-pi[20]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[21] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag7_last[-pi[21]] );
+#endif
+      score += set[eval_phase].diag7_last[-pi[21]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[22] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag6_last[-pi[22]] );
+#endif
+      score += set[eval_phase].diag6_last[-pi[22]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[23] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag6_last[-pi[23]] );
+#endif
+      score += set[eval_phase].diag6_last[-pi[23]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[24] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag6_last[-pi[24]] );
+#endif
+      score += set[eval_phase].diag6_last[-pi[24]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[25] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag6_last[-pi[25]] );
+#endif
+      score += set[eval_phase].diag6_last[-pi[25]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[26] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag5_last[-pi[26]] );
+#endif
+      score += set[eval_phase].diag5_last[-pi[26]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[27] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag5_last[-pi[27]] );
+#endif
+      score += set[eval_phase].diag5_last[-pi[27]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[28] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag5_last[-pi[28]] );
+#endif
+      score += set[eval_phase].diag5_last[-pi[28]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[29] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag5_last[-pi[29]] );
+#endif
+      score += set[eval_phase].diag5_last[-pi[29]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[30] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag4_last[-pi[30]] );
+#endif
+      score += set[eval_phase].diag4_last[-pi[30]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[31] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag4_last[-pi[31]] );
+#endif
+      score += set[eval_phase].diag4_last[-pi[31]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[32] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag4_last[-pi[32]] );
+#endif
+      score += set[eval_phase].diag4_last[-pi[32]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[33] );
+      fprintf( stream, "score=%d\n", set[eval_phase].diag4_last[-pi[33]] );
+#endif
+      score += set[eval_phase].diag4_last[-pi[33]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[34] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner33_last[-pi[34]] );
+#endif
+      score += set[eval_phase].corner33_last[-pi[34]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[35] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner33_last[-pi[35]] );
+#endif
+      score += set[eval_phase].corner33_last[-pi[35]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[36] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner33_last[-pi[36]] );
+#endif
+      score += set[eval_phase].corner33_last[-pi[36]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[37] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner33_last[-pi[37]] );
+#endif
+      score += set[eval_phase].corner33_last[-pi[37]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[38] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pi[38]] );
+#endif
+      score += set[eval_phase].corner52_last[-pi[38]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[39] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pi[39]] );
+#endif
+      score += set[eval_phase].corner52_last[-pi[39]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[40] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pi[40]] );
+#endif
+      score += set[eval_phase].corner52_last[-pi[40]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[41] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pi[41]] );
+#endif
+      score += set[eval_phase].corner52_last[-pi[41]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[42] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pi[42]] );
+#endif
+      score += set[eval_phase].corner52_last[-pi[42]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[43] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pi[43]] );
+#endif
+      score += set[eval_phase].corner52_last[-pi[43]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[44] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pi[44]] );
+#endif
+      score += set[eval_phase].corner52_last[-pi[44]];
+#ifdef LOG_EVAL
+      fprintf( stream, "pattern=%d\n", pi[45] );
+      fprintf( stream, "score=%d\n", set[eval_phase].corner52_last[-pi[45]] );
+#endif
+      score += set[eval_phase].corner52_last[-pi[45]];
+    }
   }
 
 #ifdef LOG_EVAL

--- a/src/globals.c
+++ b/src/globals.c
@@ -15,6 +15,8 @@
 
 /* Global variables */
 
+_Thread_local BitBoard board_bits[3];
+
 _Thread_local int pv[MAX_SEARCH_DEPTH][MAX_SEARCH_DEPTH];
 _Thread_local int pv_depth[MAX_SEARCH_DEPTH];
 int score_sheet_row;
@@ -22,3 +24,29 @@ _Thread_local int piece_count[3][MAX_SEARCH_DEPTH];
 int black_moves[60];
 int white_moves[60];
 _Thread_local Board board;
+
+
+/*
+  SET_BOARD_BITS
+  Rebuild the bitboards from the array board.  Called wherever the
+  array is set up other than by MAKE_MOVE -- the same places that
+  resynchronise the hash code and the evaluation pattern indices.
+*/
+
+void
+set_board_bits( void ) {
+  int i, j;
+
+  board_bits[BLACKSQ] = 0;
+  board_bits[WHITESQ] = 0;
+  board_bits[EMPTY] = 0;
+
+  for ( i = 1; i <= 8; i++ )
+    for ( j = 1; j <= 8; j++ ) {
+      int pos = 10 * i + j;
+      if ( board[pos] == BLACKSQ )
+	board_bits[BLACKSQ] |= square_mask[pos];
+      else if ( board[pos] == WHITESQ )
+	board_bits[WHITESQ] |= square_mask[pos];
+    }
+}

--- a/src/globals.h
+++ b/src/globals.h
@@ -15,6 +15,7 @@
 
 
 
+#include "bitboard.h"
 #include "constant.h"
 
 
@@ -51,6 +52,15 @@ extern int white_moves[60];
 /* Holds the current board position. Updated as the search progresses,
    but all updates must be reversed when the search stops. */
 extern _Thread_local Board board;
+
+/* The same position as BOARD, one bit per square, indexed by colour.
+   Maintained by MAKE_MOVE and UNMAKE_MOVE alongside the array, and
+   resynchronised from it by SET_BOARD_BITS wherever the array is set
+   up wholesale. */
+extern _Thread_local BitBoard board_bits[3];
+
+void
+set_board_bits( void );
 
 
 #endif  /* GLOBALS_H */

--- a/src/moves.c
+++ b/src/moves.c
@@ -12,6 +12,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "bitbtest.h"
 #include "cntflip.h"
 #include "constant.h"
 #include "doflip.h"
@@ -52,7 +53,9 @@ const int move_offset[8] = { 1, -1, 9, -9, 10, -10, 11, -11 };
 
 /* Local variables */
 
-static _Thread_local int flip_count[65];
+/* The discs turned by the move made at each stage, so that
+   UNMAKE_MOVE can give them back without walking the board. */
+static _Thread_local BitBoard flip_mask[65];
 static _Thread_local int sweep_status[MAX_SEARCH_DEPTH];
 
 
@@ -208,42 +211,103 @@ game_in_progress( void ) {
 
 
 /*
+  APPLY_FLIPS
+  Write the discs turned by a move into the array board, and fold them
+  into the hash difference when the caller wants one.  The mask comes
+  straight out of the bitboard flip test, so there is nothing to look
+  up first.
+*/
+
+static INLINE void
+apply_flips( BitBoard mask, int side_to_move, int update_hash,
+	     unsigned int *diff1, unsigned int *diff2 ) {
+  unsigned int d1 = 0, d2 = 0;
+
+  while ( mask != 0 ) {
+    int sq = square_of_bit[FIRST_BIT( mask )];
+    mask &= mask - 1;
+    board[sq] = side_to_move;
+    if ( update_hash ) {
+      d1 ^= hash_flip1[sq];
+      d2 ^= hash_flip2[sq];
+    }
+  }
+
+  *diff1 = d1;
+  *diff2 = d2;
+}
+
+
+/*
+  UNDO_FLIPS
+  Give the discs of MASK back to the opponent, in the array board, in
+  the bitboards and in the pattern indices, and empty the played
+  square.  BOARD[MOVE] has already been cleared by the caller.
+*/
+
+static INLINE void
+undo_flips( BitBoard mask, int side_to_move, int move ) {
+  int oppcol = OPP( side_to_move );
+  BitBoard m = mask;
+
+  while ( m != 0 ) {
+    int sq = square_of_bit[FIRST_BIT( m ) ];
+    m &= m - 1;
+    board[sq] = oppcol;
+  }
+
+  board_bits[side_to_move] &= ~(mask | square_mask[move]);
+  board_bits[oppcol] |= mask;
+
+  update_pattern_indices( side_to_move, move, mask, -1 );
+}
+
+
+/*
    MAKE_MOVE
    side_to_move = the side that is making the move
    move = the position giving the move
 
    Makes the necessary changes on the board and updates the
    counters.
+
+   The discs to turn are found with the bitboard flip test rather than
+   by walking the array board in eight directions: it is branch-free,
+   and the set of turned discs falls out as a mask, which is what the
+   board write, the hash difference and the pattern indices all want.
 */
 
 INLINE int
 make_move( int side_to_move, int move, int update_hash ) {
   int flipped;
   unsigned int diff1, diff2;
+  BitBoard my_bits = board_bits[side_to_move];
+  BitBoard opp_bits = board_bits[OPP( side_to_move )];
+  BitBoard mask, new_my_bits;
 
+  flipped = TestFlips_bitboard_to( move, my_bits, opp_bits, &new_my_bits );
+  if ( flipped == 0 )
+    return 0;
+
+  /* NEW_MY_BITS is the mover's discs with the turned ones and the
+     played square added, so the turned ones alone are what it gained. */
+  mask = new_my_bits & ~my_bits & ~square_mask[move];
+
+  board_bits[side_to_move] = new_my_bits;
+  board_bits[OPP( side_to_move )] = opp_bits & ~mask;
+  flip_mask[disks_played] = mask;
+
+  apply_flips( mask, side_to_move, update_hash, &diff1, &diff2 );
+
+  hash_stored1[disks_played] = hash1;
+  hash_stored2[disks_played] = hash2;
   if ( update_hash ) {
-    flipped = DoFlips_hash( move, side_to_move );
-    if ( flipped == 0 )
-      return 0;
-    diff1 = hash_update1 ^ hash_put_value1[side_to_move][move];
-    diff2 = hash_update2 ^ hash_put_value2[side_to_move][move];
-    hash_stored1[disks_played] = hash1;
-    hash_stored2[disks_played] = hash2;
-    hash1 ^= diff1;
-    hash2 ^= diff2;
+    hash1 ^= diff1 ^ hash_put_value1[side_to_move][move];
+    hash2 ^= diff2 ^ hash_put_value2[side_to_move][move];
   }
-  else {
-    flipped = DoFlips_no_hash( move, side_to_move );
-    if ( flipped == 0 )
-      return 0;
-    hash_stored1[disks_played] = hash1;
-    hash_stored2[disks_played] = hash2;
-  }
-
-  flip_count[disks_played] = flipped;
 
   board[move] = side_to_move;
-  update_pattern_indices( side_to_move, move, flipped, 1 );
+  update_pattern_indices( side_to_move, move, mask, 1 );
 
   if ( side_to_move == BLACKSQ ) {
     piece_count[BLACKSQ][disks_played + 1] =
@@ -277,15 +341,25 @@ make_move( int side_to_move, int move, int update_hash ) {
 INLINE int
 make_move_no_hash( int side_to_move, int move ) {
   int flipped;
+  unsigned int diff1, diff2;
+  BitBoard my_bits = board_bits[side_to_move];
+  BitBoard opp_bits = board_bits[OPP( side_to_move )];
+  BitBoard mask, new_my_bits;
 
-  flipped = DoFlips_no_hash( move, side_to_move );
+  flipped = TestFlips_bitboard_to( move, my_bits, opp_bits, &new_my_bits );
   if ( flipped == 0 )
     return 0;
 
-  flip_count[disks_played] = flipped;
+  mask = new_my_bits & ~my_bits & ~square_mask[move];
+
+  board_bits[side_to_move] = new_my_bits;
+  board_bits[OPP( side_to_move )] = opp_bits & ~mask;
+  flip_mask[disks_played] = mask;
+
+  apply_flips( mask, side_to_move, FALSE, &diff1, &diff2 );
 
   board[move] = side_to_move;
-  update_pattern_indices( side_to_move, move, flipped, 1 );
+  update_pattern_indices( side_to_move, move, mask, 1 );
 
 #if 1
   if ( side_to_move == BLACKSQ ) {
@@ -326,10 +400,7 @@ unmake_move( int side_to_move, int move ) {
   hash1 = hash_stored1[disks_played];
   hash2 = hash_stored2[disks_played];
 
-  /* The flipped discs are still on the flip stack here. */
-  update_pattern_indices( side_to_move, move, flip_count[disks_played], -1 );
-
-  UndoFlips_inlined( flip_count[disks_played], OPP( side_to_move ) );
+  undo_flips( flip_mask[disks_played], side_to_move, move );
 }
 
 
@@ -345,10 +416,7 @@ unmake_move_no_hash( int side_to_move, int move ) {
 
   disks_played--;
 
-  /* The flipped discs are still on the flip stack here. */
-  update_pattern_indices( side_to_move, move, flip_count[disks_played], -1 );
-
-  UndoFlips_inlined( flip_count[disks_played], OPP( side_to_move ) );
+  undo_flips( flip_mask[disks_played], side_to_move, move );
 }
 
 

--- a/src/moves.c
+++ b/src/moves.c
@@ -12,6 +12,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "bitbmob.h"
 #include "bitbtest.h"
 #include "cntflip.h"
 #include "constant.h"
@@ -56,7 +57,6 @@ const int move_offset[8] = { 1, -1, 9, -9, 10, -10, 11, -11 };
 /* The discs turned by the move made at each stage, so that
    UNMAKE_MOVE can give them back without walking the board. */
 static _Thread_local BitBoard flip_mask[65];
-static _Thread_local int sweep_status[MAX_SEARCH_DEPTH];
 
 
 
@@ -88,17 +88,6 @@ init_moves( void ) {
 
 
 /*
-   RESET_GENERATION
-   Prepare for move generation at a given level in the tree.
-*/
-
-INLINE static void
-reset_generation( int side_to_move ) {
-  sweep_status[disks_played] = 0;
-}
-
-
-/*
    GENERATE_SPECIFIC
 */
 
@@ -110,57 +99,35 @@ generate_specific( int curr_move, int side_to_move ) {
 
 
 /*
-   GENERATE_MOVE
-   side_to_move = the side to generate moves for
-
-   Generate the next move in the ordering. This way not all moves possible
-   in a position are generated, only those who need be considered.
-*/
-
-INLINE int
-generate_move(int side_to_move) {
-  int move;
-  int move_index = 0;
-
-  move_index = sweep_status[disks_played];
-  while ( move_index < MOVE_ORDER_SIZE ) {
-    move = sorted_move_order[disks_played][move_index];
-    if ( (board[move] == EMPTY) &&
-	 generate_specific( move, side_to_move ) ) {
-      sweep_status[disks_played] = move_index + 1;
-      return move;
-    }
-    else
-      move_index++;
-  }
-
-  sweep_status[disks_played] = move_index;
-  return ILLEGAL;
-}
-
-
-
-/*
    GENERATE_ALL
    Generates a list containing all the moves possible in a position.
+
+   Every legal move comes out of one bitboard fill, so the list is
+   built by walking the move order once and keeping the squares the
+   fill marked.  The order is the one the caller expects; only the
+   legality test changed, from an eight-direction walk of the array
+   per candidate square to a lookup in the mask.
 */
 
 INLINE void
 generate_all( int side_to_move ) {
-  int count, curr_move;
+  BitBoard moves = bitboard_moves( board_bits[side_to_move],
+				   board_bits[OPP( side_to_move )] );
+  const int *order = sorted_move_order[disks_played];
+  int count = 0;
+  int i;
 
-  reset_generation( side_to_move );
-  count = 0;
-  curr_move = generate_move( side_to_move );
-  while ( curr_move != ILLEGAL ) {
-    move_list[disks_played][count] = curr_move;
-    count++;
-    curr_move = generate_move( side_to_move );
+  for ( i = 0; i < MOVE_ORDER_SIZE; i++ ) {
+    int move = order[i];
+    if ( moves & square_mask[move] ) {
+      move_list[disks_played][count] = move;
+      count++;
+    }
   }
+
   move_list[disks_played][count] = ILLEGAL;
   move_count[disks_played] = count;
 }
-
 
 
 /*

--- a/src/moves.c
+++ b/src/moves.c
@@ -243,6 +243,7 @@ make_move( int side_to_move, int move, int update_hash ) {
   flip_count[disks_played] = flipped;
 
   board[move] = side_to_move;
+  update_pattern_indices( side_to_move, move, flipped, 1 );
 
   if ( side_to_move == BLACKSQ ) {
     piece_count[BLACKSQ][disks_played + 1] =
@@ -284,6 +285,7 @@ make_move_no_hash( int side_to_move, int move ) {
   flip_count[disks_played] = flipped;
 
   board[move] = side_to_move;
+  update_pattern_indices( side_to_move, move, flipped, 1 );
 
 #if 1
   if ( side_to_move == BLACKSQ ) {
@@ -324,6 +326,9 @@ unmake_move( int side_to_move, int move ) {
   hash1 = hash_stored1[disks_played];
   hash2 = hash_stored2[disks_played];
 
+  /* The flipped discs are still on the flip stack here. */
+  update_pattern_indices( side_to_move, move, flip_count[disks_played], -1 );
+
   UndoFlips_inlined( flip_count[disks_played], OPP( side_to_move ) );
 }
 
@@ -339,6 +344,9 @@ unmake_move_no_hash( int side_to_move, int move ) {
   board[move] = EMPTY;
 
   disks_played--;
+
+  /* The flipped discs are still on the flip stack here. */
+  update_pattern_indices( side_to_move, move, flip_count[disks_played], -1 );
 
   UndoFlips_inlined( flip_count[disks_played], OPP( side_to_move ) );
 }

--- a/src/moves.h
+++ b/src/moves.h
@@ -64,9 +64,6 @@ init_moves( void );
 int
 generate_specific( int curr_move, int side_to_move );
 
-int
-generate_move( int side_to_move );
-
 void
 generate_all( int side_to_move );
 

--- a/src/osfbook.c
+++ b/src/osfbook.c
@@ -942,6 +942,7 @@ do_midgame_statistics( int index, StatisticsSpec spec ) {
     display_board( stdout, board, BLACKSQ, FALSE, FALSE, FALSE );
     setup_hash( FALSE );
     determine_hash_values( side_to_move, board );
+    determine_pattern_indices();
     for ( depth = 1; depth <= spec.max_depth; depth += 2 ) {
       (void) middle_game( side_to_move, depth, FALSE, &dummy_info );
       eval_list[depth] = root_eval;
@@ -954,6 +955,7 @@ do_midgame_statistics( int index, StatisticsSpec spec ) {
 #endif
     setup_hash( FALSE );
     determine_hash_values( side_to_move, board );
+    determine_pattern_indices();
     for ( depth = 2; depth <= spec.max_depth; depth += 2 ) {
       (void) middle_game( side_to_move, depth, FALSE, &dummy_info );
       eval_list[depth] = root_eval;
@@ -1050,6 +1052,7 @@ endgame_correlation( int side_to_move, int best_score, int best_move,
   display_board( stdout, board, BLACKSQ, FALSE, FALSE, FALSE );
   set_hash_transformation( labs( my_random() ), labs( my_random() ) );
   determine_hash_values( side_to_move, board );
+  determine_pattern_indices();
   for ( depth = 1; depth <= spec.max_depth; depth++ ) {
     (void) middle_game( side_to_move, depth, FALSE, &dummy_info );
     eval_list[depth] = root_eval;
@@ -1124,6 +1127,7 @@ do_endgame_statistics( int index, StatisticsSpec spec ) {
        (my_random() % 1000) < 1000.0 * spec.prob) {
     setup_hash( FALSE );
     determine_hash_values( side_to_move, board );
+    determine_pattern_indices();
 #ifdef TEXT_BASED
     printf( "\nSolving with %d empty...\n\n", 60 - disks_played );
 #endif
@@ -1219,6 +1223,7 @@ nega_scout( int depth, int allow_mpc, int side_to_move,
 
   clear_hash_drafts();
   determine_hash_values( side_to_move, board );
+  determine_pattern_indices();
 
   /* First determine the best move in the current position
      and its score when searched to depth DEPTH.
@@ -1742,6 +1747,7 @@ do_correct( int index, int max_empty, int full_solve,
 
   generate_all( side_to_move );
   determine_hash_values( side_to_move, board );
+  determine_pattern_indices();
 
   if ( disks_played >= 60 - max_empty ) {
     really_evaluate =
@@ -2590,6 +2596,7 @@ add_new_game( int move_count, short *game_move_list,
   else {
     generate_all( side_to_move );
     determine_hash_values( side_to_move, board );
+    determine_pattern_indices();
 #ifdef TEXT_BASED
     if ( echo ) {
       puts( "" );
@@ -2657,6 +2664,7 @@ add_new_game( int move_count, short *game_move_list,
 	side_to_move = WHITESQ;
       generate_all( side_to_move );
       determine_hash_values( side_to_move, board );
+      determine_pattern_indices();
       if ( disks_played >= 60 - max_full_solve ) {
 	/* Only solve the position if it hasn't been solved already */
 	if ( !(node[this_node].flags & FULL_SOLVED) ) {

--- a/src/osfbook.c
+++ b/src/osfbook.c
@@ -943,6 +943,7 @@ do_midgame_statistics( int index, StatisticsSpec spec ) {
     setup_hash( FALSE );
     determine_hash_values( side_to_move, board );
     determine_pattern_indices();
+    set_board_bits();
     for ( depth = 1; depth <= spec.max_depth; depth += 2 ) {
       (void) middle_game( side_to_move, depth, FALSE, &dummy_info );
       eval_list[depth] = root_eval;
@@ -956,6 +957,7 @@ do_midgame_statistics( int index, StatisticsSpec spec ) {
     setup_hash( FALSE );
     determine_hash_values( side_to_move, board );
     determine_pattern_indices();
+    set_board_bits();
     for ( depth = 2; depth <= spec.max_depth; depth += 2 ) {
       (void) middle_game( side_to_move, depth, FALSE, &dummy_info );
       eval_list[depth] = root_eval;
@@ -1053,6 +1055,7 @@ endgame_correlation( int side_to_move, int best_score, int best_move,
   set_hash_transformation( labs( my_random() ), labs( my_random() ) );
   determine_hash_values( side_to_move, board );
   determine_pattern_indices();
+  set_board_bits();
   for ( depth = 1; depth <= spec.max_depth; depth++ ) {
     (void) middle_game( side_to_move, depth, FALSE, &dummy_info );
     eval_list[depth] = root_eval;
@@ -1128,6 +1131,7 @@ do_endgame_statistics( int index, StatisticsSpec spec ) {
     setup_hash( FALSE );
     determine_hash_values( side_to_move, board );
     determine_pattern_indices();
+    set_board_bits();
 #ifdef TEXT_BASED
     printf( "\nSolving with %d empty...\n\n", 60 - disks_played );
 #endif
@@ -1224,6 +1228,7 @@ nega_scout( int depth, int allow_mpc, int side_to_move,
   clear_hash_drafts();
   determine_hash_values( side_to_move, board );
   determine_pattern_indices();
+  set_board_bits();
 
   /* First determine the best move in the current position
      and its score when searched to depth DEPTH.
@@ -1748,6 +1753,7 @@ do_correct( int index, int max_empty, int full_solve,
   generate_all( side_to_move );
   determine_hash_values( side_to_move, board );
   determine_pattern_indices();
+  set_board_bits();
 
   if ( disks_played >= 60 - max_empty ) {
     really_evaluate =
@@ -2597,6 +2603,7 @@ add_new_game( int move_count, short *game_move_list,
     generate_all( side_to_move );
     determine_hash_values( side_to_move, board );
     determine_pattern_indices();
+    set_board_bits();
 #ifdef TEXT_BASED
     if ( echo ) {
       puts( "" );
@@ -2665,6 +2672,7 @@ add_new_game( int move_count, short *game_move_list,
       generate_all( side_to_move );
       determine_hash_values( side_to_move, board );
       determine_pattern_indices();
+      set_board_bits();
       if ( disks_played >= 60 - max_full_solve ) {
 	/* Only solve the position if it hasn't been solved already */
 	if ( !(node[this_node].flags & FULL_SOLVED) ) {

--- a/src/patterns.c
+++ b/src/patterns.c
@@ -489,15 +489,15 @@ static const struct {
    sparse form needed.  The doubled table serves the flipped discs,
    whose trit moves by two. */
 
-static unsigned short pattern_weight[100][EVAL_PATTERN_SLOTS];
-static unsigned short pattern_weight2[100][EVAL_PATTERN_SLOTS];
+static unsigned short pattern_weight[64][EVAL_PATTERN_SLOTS];
+static unsigned short pattern_weight2[64][EVAL_PATTERN_SLOTS];
 
 
 void
 init_pattern_dependencies( void ) {
   int p, i, sq;
 
-  for ( sq = 0; sq < 100; sq++ )
+  for ( sq = 0; sq < 64; sq++ )
     for ( p = 0; p < EVAL_PATTERN_SLOTS; p++ ) {
       pattern_weight[sq][p] = 0;
       pattern_weight2[sq][p] = 0;
@@ -507,7 +507,9 @@ init_pattern_dependencies( void ) {
     for ( i = 0; i < eval_pattern[p].len; i++ ) {
       unsigned short w = (unsigned short)
 	pow3[eval_pattern[p].len - 1 - i];
-      sq = eval_pattern[p].squares[i];
+      /* Indexed by bit number, so that the rows the flipped discs
+	 need are reached straight from the flip mask. */
+      sq = bit_position[eval_pattern[p].squares[i]];
       pattern_weight[sq][p] = w;
       pattern_weight2[sq][p] = 2 * w;
     }
@@ -550,12 +552,9 @@ determine_pattern_indices( void ) {
 */
 
 void
-update_pattern_indices( int color, int move, int flipped, int dir ) {
-  int i;
-  /* BOARD and FLIP_STACK are thread-local; resolve them once. */
+update_pattern_indices( int color, int move, BitBoard flipped, int dir ) {
+  /* EVAL_PATTERN_INDEX is thread-local; resolve it once. */
   unsigned short *pi = eval_pattern_index;
-  const int *b = board;
-  int *const *fs = flip_stack;
   const int subtract = ((color == BLACKSQ) == (dir > 0));
 
 #if defined( __ARM_NEON )
@@ -571,6 +570,16 @@ update_pattern_indices( int color, int move, int flipped, int dir ) {
     p5 = op( p5, vld1q_u16( w + 40 ) );				\
   }
 
+#define APPLY_MASK( op )					\
+  {								\
+    BitBoard m = flipped;					\
+    while ( m != 0 ) {						\
+      APPLY_ROW( op, pattern_weight2, FIRST_BIT( m ) );		\
+      m &= m - 1;						\
+    }								\
+    APPLY_ROW( op, pattern_weight, bit_position[move] );	\
+  }
+
   {
     uint16x8_t p0 = vld1q_u16( pi      );
     uint16x8_t p1 = vld1q_u16( pi +  8 );
@@ -579,16 +588,10 @@ update_pattern_indices( int color, int move, int flipped, int dir ) {
     uint16x8_t p4 = vld1q_u16( pi + 32 );
     uint16x8_t p5 = vld1q_u16( pi + 40 );
 
-    if ( subtract ) {
-      for ( i = 1; i <= flipped; i++ )
-	APPLY_ROW( vsubq_u16, pattern_weight2, (int) (fs[-i] - b) );
-      APPLY_ROW( vsubq_u16, pattern_weight, move );
-    }
-    else {
-      for ( i = 1; i <= flipped; i++ )
-	APPLY_ROW( vaddq_u16, pattern_weight2, (int) (fs[-i] - b) );
-      APPLY_ROW( vaddq_u16, pattern_weight, move );
-    }
+    if ( subtract )
+      APPLY_MASK( vsubq_u16 )
+    else
+      APPLY_MASK( vaddq_u16 )
 
     vst1q_u16( pi,      p0 );
     vst1q_u16( pi +  8, p1 );
@@ -598,30 +601,32 @@ update_pattern_indices( int color, int move, int flipped, int dir ) {
     vst1q_u16( pi + 40, p5 );
   }
 
+#undef APPLY_MASK
 #undef APPLY_ROW
 
 #else
 
   {
     int j;
+    BitBoard m;
 
     if ( subtract ) {
-      for ( i = 1; i <= flipped; i++ ) {
-	const unsigned short *w = pattern_weight2[fs[-i] - b];
+      for ( m = flipped; m != 0; m &= m - 1 ) {
+	const unsigned short *w = pattern_weight2[FIRST_BIT( m )];
 	for ( j = 0; j < EVAL_PATTERN_SLOTS; j++ )
 	  pi[j] -= w[j];
       }
       for ( j = 0; j < EVAL_PATTERN_SLOTS; j++ )
-	pi[j] -= pattern_weight[move][j];
+	pi[j] -= pattern_weight[bit_position[move]][j];
     }
     else {
-      for ( i = 1; i <= flipped; i++ ) {
-	const unsigned short *w = pattern_weight2[fs[-i] - b];
+      for ( m = flipped; m != 0; m &= m - 1 ) {
+	const unsigned short *w = pattern_weight2[FIRST_BIT( m )];
 	for ( j = 0; j < EVAL_PATTERN_SLOTS; j++ )
 	  pi[j] += w[j];
       }
       for ( j = 0; j < EVAL_PATTERN_SLOTS; j++ )
-	pi[j] += pattern_weight[move][j];
+	pi[j] += pattern_weight[bit_position[move]][j];
     }
   }
 

--- a/src/patterns.c
+++ b/src/patterns.c
@@ -17,6 +17,11 @@
 #include "globals.h"
 #include "macros.h"
 #include "patterns.h"
+#include "unflip.h"
+
+#if defined( __ARM_NEON )
+#include <arm_neon.h>
+#endif
 
 
 
@@ -361,6 +366,7 @@ init_patterns( void ) {
     }
 
   pattern_dependency();
+  init_pattern_dependencies();
 
   /* These values needed for compatibility with the old book format */
 
@@ -395,4 +401,252 @@ compute_line_patterns( int *in_board ) {
       row_pattern[row_no[pos]] += mask * pow3[row_index[pos]];
       col_pattern[col_no[pos]] += mask * pow3[col_index[pos]];
     }
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Incremental evaluation pattern indices                             */
+/*                                                                    */
+/* pattern_evaluation() used to rebuild the base-3 index of every     */
+/* pattern from the board at each leaf.  The indices are maintained   */
+/* incrementally instead: a flipped disc changes one trit of each     */
+/* pattern its square belongs to, so MAKE_MOVE adds the trit deltas   */
+/* for the discs it turns and UNMAKE_MOVE subtracts them again.  The  */
+/* indices are kept in black perspective; the white-to-move lookup    */
+/* reads the coefficient tables backwards through the *_last          */
+/* pointers, exactly as the evaluation always has.                    */
+
+/* The indices are held as unsigned 16-bit lanes so that a whole move's
+   worth of update is a handful of vector adds.  The largest index is
+   3^10 - 1 = 59048 and the largest weight 2 * 3^9 = 39366, both inside
+   the range, and the arithmetic is exact modulo 2^16: intermediate
+   lanes may wrap while a move is being applied, but the value at the
+   end of the update is the true one.  The count is padded to a
+   multiple of eight so the tail is a whole vector. */
+
+#define EVAL_PATTERN_COUNT   46
+#define EVAL_PATTERN_SLOTS   48
+
+_Thread_local unsigned short eval_pattern_index[EVAL_PATTERN_SLOTS];
+
+static const struct {
+  short len;
+  short squares[10];   /* most significant trit first */
+} eval_pattern[EVAL_PATTERN_COUNT] = {
+  { 10, { 72, 22, 81, 71, 61, 51, 41, 31, 21, 11 } },	/* afile2x */
+  { 10, { 77, 27, 88, 78, 68, 58, 48, 38, 28, 18 } },	/* afile2x */
+  { 10, { 27, 22, 18, 17, 16, 15, 14, 13, 12, 11 } },	/* afile2x */
+  { 10, { 77, 72, 88, 87, 86, 85, 84, 83, 82, 81 } },	/* afile2x */
+  { 8, { 82, 72, 62, 52, 42, 32, 22, 12,  0,  0 } },	/* bfile */
+  { 8, { 87, 77, 67, 57, 47, 37, 27, 17,  0,  0 } },	/* bfile */
+  { 8, { 28, 27, 26, 25, 24, 23, 22, 21,  0,  0 } },	/* bfile */
+  { 8, { 78, 77, 76, 75, 74, 73, 72, 71,  0,  0 } },	/* bfile */
+  { 8, { 83, 73, 63, 53, 43, 33, 23, 13,  0,  0 } },	/* cfile */
+  { 8, { 86, 76, 66, 56, 46, 36, 26, 16,  0,  0 } },	/* cfile */
+  { 8, { 38, 37, 36, 35, 34, 33, 32, 31,  0,  0 } },	/* cfile */
+  { 8, { 68, 67, 66, 65, 64, 63, 62, 61,  0,  0 } },	/* cfile */
+  { 8, { 84, 74, 64, 54, 44, 34, 24, 14,  0,  0 } },	/* dfile */
+  { 8, { 85, 75, 65, 55, 45, 35, 25, 15,  0,  0 } },	/* dfile */
+  { 8, { 48, 47, 46, 45, 44, 43, 42, 41,  0,  0 } },	/* dfile */
+  { 8, { 58, 57, 56, 55, 54, 53, 52, 51,  0,  0 } },	/* dfile */
+  { 8, { 88, 77, 66, 55, 44, 33, 22, 11,  0,  0 } },	/* diag8 */
+  { 8, { 81, 72, 63, 54, 45, 36, 27, 18,  0,  0 } },	/* diag8 */
+  { 7, { 78, 67, 56, 45, 34, 23, 12,  0,  0,  0 } },	/* diag7 */
+  { 7, { 87, 76, 65, 54, 43, 32, 21,  0,  0,  0 } },	/* diag7 */
+  { 7, { 71, 62, 53, 44, 35, 26, 17,  0,  0,  0 } },	/* diag7 */
+  { 7, { 82, 73, 64, 55, 46, 37, 28,  0,  0,  0 } },	/* diag7 */
+  { 6, { 68, 57, 46, 35, 24, 13,  0,  0,  0,  0 } },	/* diag6 */
+  { 6, { 86, 75, 64, 53, 42, 31,  0,  0,  0,  0 } },	/* diag6 */
+  { 6, { 61, 52, 43, 34, 25, 16,  0,  0,  0,  0 } },	/* diag6 */
+  { 6, { 83, 74, 65, 56, 47, 38,  0,  0,  0,  0 } },	/* diag6 */
+  { 5, { 58, 47, 36, 25, 14,  0,  0,  0,  0,  0 } },	/* diag5 */
+  { 5, { 85, 74, 63, 52, 41,  0,  0,  0,  0,  0 } },	/* diag5 */
+  { 5, { 51, 42, 33, 24, 15,  0,  0,  0,  0,  0 } },	/* diag5 */
+  { 5, { 84, 75, 66, 57, 48,  0,  0,  0,  0,  0 } },	/* diag5 */
+  { 4, { 48, 37, 26, 15,  0,  0,  0,  0,  0,  0 } },	/* diag4 */
+  { 4, { 84, 73, 62, 51,  0,  0,  0,  0,  0,  0 } },	/* diag4 */
+  { 4, { 41, 32, 23, 14,  0,  0,  0,  0,  0,  0 } },	/* diag4 */
+  { 4, { 85, 76, 67, 58,  0,  0,  0,  0,  0,  0 } },	/* diag4 */
+  { 9, { 33, 32, 31, 23, 22, 21, 13, 12, 11,  0 } },	/* corner33 */
+  { 9, { 63, 62, 61, 73, 72, 71, 83, 82, 81,  0 } },	/* corner33 */
+  { 9, { 36, 37, 38, 26, 27, 28, 16, 17, 18,  0 } },	/* corner33 */
+  { 9, { 66, 67, 68, 76, 77, 78, 86, 87, 88,  0 } },	/* corner33 */
+  { 10, { 25, 24, 23, 22, 21, 15, 14, 13, 12, 11 } },	/* corner52 */
+  { 10, { 75, 74, 73, 72, 71, 85, 84, 83, 82, 81 } },	/* corner52 */
+  { 10, { 24, 25, 26, 27, 28, 14, 15, 16, 17, 18 } },	/* corner52 */
+  { 10, { 74, 75, 76, 77, 78, 84, 85, 86, 87, 88 } },	/* corner52 */
+  { 10, { 52, 42, 32, 22, 12, 51, 41, 31, 21, 11 } },	/* corner52 */
+  { 10, { 57, 47, 37, 27, 17, 58, 48, 38, 28, 18 } },	/* corner52 */
+  { 10, { 42, 52, 62, 72, 82, 41, 51, 61, 71, 81 } },	/* corner52 */
+  { 10, { 47, 57, 67, 77, 87, 48, 58, 68, 78, 88 } },	/* corner52 */
+};
+
+/* The trit weight of every square in every pattern, laid out densely
+   so that one square's contribution to all 46 indices is six vectors.
+   A square belongs to eight patterns at the most, so the rows are
+   mostly zero; the zero lanes cost nothing but make the update
+   branch-free and free of the scattered read-modify-writes that the
+   sparse form needed.  The doubled table serves the flipped discs,
+   whose trit moves by two. */
+
+static unsigned short pattern_weight[100][EVAL_PATTERN_SLOTS];
+static unsigned short pattern_weight2[100][EVAL_PATTERN_SLOTS];
+
+
+void
+init_pattern_dependencies( void ) {
+  int p, i, sq;
+
+  for ( sq = 0; sq < 100; sq++ )
+    for ( p = 0; p < EVAL_PATTERN_SLOTS; p++ ) {
+      pattern_weight[sq][p] = 0;
+      pattern_weight2[sq][p] = 0;
+    }
+
+  for ( p = 0; p < EVAL_PATTERN_COUNT; p++ )
+    for ( i = 0; i < eval_pattern[p].len; i++ ) {
+      unsigned short w = (unsigned short)
+	pow3[eval_pattern[p].len - 1 - i];
+      sq = eval_pattern[p].squares[i];
+      pattern_weight[sq][p] = w;
+      pattern_weight2[sq][p] = 2 * w;
+    }
+}
+
+
+/*
+  DETERMINE_PATTERN_INDICES
+  Recompute all indices from the board; the incremental updates keep
+  them current from here on.
+*/
+
+void
+determine_pattern_indices( void ) {
+  int p, i, index;
+
+  for ( p = 0; p < EVAL_PATTERN_COUNT; p++ ) {
+    index = 0;
+    for ( i = 0; i < eval_pattern[p].len; i++ )
+      index = 3 * index + board[eval_pattern[p].squares[i]];
+    eval_pattern_index[p] = (unsigned short) index;
+  }
+  for ( p = EVAL_PATTERN_COUNT; p < EVAL_PATTERN_SLOTS; p++ )
+    eval_pattern_index[p] = 0;
+}
+
+
+/*
+  UPDATE_PATTERN_INDICES
+  Apply (DIR = 1) or take back (DIR = -1) the index changes of a move:
+  the played square goes from EMPTY to COLOR and the FLIPPED entries
+  on top of the flip stack go from the opponent to COLOR.  Called by
+  MAKE_MOVE while the flipped discs are still on the stack.
+
+  Trits are the board values, BLACKSQ 0, EMPTY 1, WHITESQ 2, so playing
+  black lowers a trit and playing white raises it; taking the move back
+  reverses that.  Every square of the move therefore moves the indices
+  in the same direction, and the whole update is one sign applied to a
+  few rows of the weight tables.
+*/
+
+void
+update_pattern_indices( int color, int move, int flipped, int dir ) {
+  int i;
+  /* BOARD and FLIP_STACK are thread-local; resolve them once. */
+  unsigned short *pi = eval_pattern_index;
+  const int *b = board;
+  int *const *fs = flip_stack;
+  const int subtract = ((color == BLACKSQ) == (dir > 0));
+
+#if defined( __ARM_NEON )
+
+#define APPLY_ROW( op, table, sq )				\
+  {								\
+    const unsigned short *w = (table)[sq];			\
+    p0 = op( p0, vld1q_u16( w      ) );				\
+    p1 = op( p1, vld1q_u16( w +  8 ) );				\
+    p2 = op( p2, vld1q_u16( w + 16 ) );				\
+    p3 = op( p3, vld1q_u16( w + 24 ) );				\
+    p4 = op( p4, vld1q_u16( w + 32 ) );				\
+    p5 = op( p5, vld1q_u16( w + 40 ) );				\
+  }
+
+  {
+    uint16x8_t p0 = vld1q_u16( pi      );
+    uint16x8_t p1 = vld1q_u16( pi +  8 );
+    uint16x8_t p2 = vld1q_u16( pi + 16 );
+    uint16x8_t p3 = vld1q_u16( pi + 24 );
+    uint16x8_t p4 = vld1q_u16( pi + 32 );
+    uint16x8_t p5 = vld1q_u16( pi + 40 );
+
+    if ( subtract ) {
+      for ( i = 1; i <= flipped; i++ )
+	APPLY_ROW( vsubq_u16, pattern_weight2, (int) (fs[-i] - b) );
+      APPLY_ROW( vsubq_u16, pattern_weight, move );
+    }
+    else {
+      for ( i = 1; i <= flipped; i++ )
+	APPLY_ROW( vaddq_u16, pattern_weight2, (int) (fs[-i] - b) );
+      APPLY_ROW( vaddq_u16, pattern_weight, move );
+    }
+
+    vst1q_u16( pi,      p0 );
+    vst1q_u16( pi +  8, p1 );
+    vst1q_u16( pi + 16, p2 );
+    vst1q_u16( pi + 24, p3 );
+    vst1q_u16( pi + 32, p4 );
+    vst1q_u16( pi + 40, p5 );
+  }
+
+#undef APPLY_ROW
+
+#else
+
+  {
+    int j;
+
+    if ( subtract ) {
+      for ( i = 1; i <= flipped; i++ ) {
+	const unsigned short *w = pattern_weight2[fs[-i] - b];
+	for ( j = 0; j < EVAL_PATTERN_SLOTS; j++ )
+	  pi[j] -= w[j];
+      }
+      for ( j = 0; j < EVAL_PATTERN_SLOTS; j++ )
+	pi[j] -= pattern_weight[move][j];
+    }
+    else {
+      for ( i = 1; i <= flipped; i++ ) {
+	const unsigned short *w = pattern_weight2[fs[-i] - b];
+	for ( j = 0; j < EVAL_PATTERN_SLOTS; j++ )
+	  pi[j] += w[j];
+      }
+      for ( j = 0; j < EVAL_PATTERN_SLOTS; j++ )
+	pi[j] += pattern_weight[move][j];
+    }
+  }
+
+#endif
+}
+
+
+/*
+  VERIFY_PATTERN_INDICES
+  Compare the incrementally maintained indices against a recomputation
+  from the board.  Debug builds call this from pattern_evaluation().
+*/
+
+void
+verify_pattern_indices( void ) {
+  int p, i, index;
+
+  for ( p = 0; p < EVAL_PATTERN_COUNT; p++ ) {
+    index = 0;
+    for ( i = 0; i < eval_pattern[p].len; i++ )
+      index = 3 * index + board[eval_pattern[p].squares[i]];
+    if ( index != (int) eval_pattern_index[p] ) {
+      fprintf( stderr, "pattern %d: incremental %d != recomputed %d\n",
+	       p, (int) eval_pattern_index[p], index );
+      abort();
+    }
+  }
 }

--- a/src/patterns.h
+++ b/src/patterns.h
@@ -15,6 +15,7 @@
 
 
 
+#include "bitboard.h"
 #include "constant.h"
 
 
@@ -137,7 +138,7 @@ void
 determine_pattern_indices( void );
 
 void
-update_pattern_indices( int color, int move, int flipped, int dir );
+update_pattern_indices( int color, int move, BitBoard flipped, int dir );
 
 void
 verify_pattern_indices( void );

--- a/src/patterns.h
+++ b/src/patterns.h
@@ -126,6 +126,22 @@ extern unsigned int modified_hi;
 
 
 
+/* The evaluation pattern indices in black perspective, maintained
+   incrementally by MAKE_MOVE/UNMAKE_MOVE.  See patterns.c. */
+extern _Thread_local unsigned short eval_pattern_index[48];
+
+void
+init_pattern_dependencies( void );
+
+void
+determine_pattern_indices( void );
+
+void
+update_pattern_indices( int color, int move, int flipped, int dir );
+
+void
+verify_pattern_indices( void );
+
 void
 init_patterns( void );
 

--- a/src/search.c
+++ b/src/search.c
@@ -22,6 +22,7 @@
 #include "globals.h"
 #include "macros.h"
 #include "moves.h"
+#include "patterns.h"
 #include "unflip.h"
 #include "search.h"
 #include "texts.h"
@@ -387,6 +388,7 @@ hash_expand_pv( int side_to_move,
   HashEntry entry;
 
   determine_hash_values( side_to_move, board );
+  determine_pattern_indices();
   new_pv_depth = 0;
   pass_count = 0;
 
@@ -622,4 +624,5 @@ search_state_load( const SearchState *state ) {
   hash1 = state->hash1;
   hash2 = state->hash2;
   disks_played = state->disks_played;
+  determine_pattern_indices();
 }

--- a/src/search.c
+++ b/src/search.c
@@ -389,6 +389,7 @@ hash_expand_pv( int side_to_move,
 
   determine_hash_values( side_to_move, board );
   determine_pattern_indices();
+  set_board_bits();
   new_pv_depth = 0;
   pass_count = 0;
 
@@ -625,4 +626,5 @@ search_state_load( const SearchState *state ) {
   hash2 = state->hash2;
   disks_played = state->disks_played;
   determine_pattern_indices();
+  set_board_bits();
 }

--- a/tests/fliptest.c
+++ b/tests/fliptest.c
@@ -30,6 +30,7 @@
 #include "constant.h"
 #include "globals.h"
 #include "bitboard.h"
+#include "bitbmob.h"
 #include "bitbtest.h"
 #include "doflip.h"
 #include "unflip.h"
@@ -75,6 +76,7 @@ main( int argc, char *argv[] ) {
     int side_to_move = (rand() & 1) ? BLACKSQ : WHITESQ;
     int fill = 20 + rand() % 75;   /* percent nonempty */
     BitBoard my_bits, opp_bits;
+    BitBoard legal = 0;
 
     for ( i = 0; i < 128; i++ )
       board[i] = OUTSIDE;
@@ -107,6 +109,9 @@ main( int argc, char *argv[] ) {
 	memcpy( board, saved, sizeof( Board ) );
 	flip_stack = stack_before;
 
+	if ( bb_count != 0 )
+	  legal |= square_mask[sq];
+
 	if ( bb_count != do_count ) {
 	  printf( "MISMATCH trial=%d sq=%c%d: "
 		  "TestFlips_bitboard=%d DoFlips=%d\n",
@@ -117,6 +122,15 @@ main( int argc, char *argv[] ) {
 	  mismatches++;
 	}
       }
+
+    /* The move generator gets the same set in one fill; generate_all()
+       relies on that instead of testing squares one at a time. */
+    if ( bitboard_moves( my_bits, opp_bits ) != legal ) {
+      printf( "MOVE MISMATCH trial=%d: bitboard_moves=%016llx expected=%016llx\n",
+	      trial, bitboard_moves( my_bits, opp_bits ), legal );
+      print_pos( side_to_move );
+      mismatches++;
+    }
   }
 
   if ( mismatches == 0 ) {


### PR DESCRIPTION
Stacked on #20 — needs the single-word `BitBoard` from there.

Three changes to the midgame search. Deterministic self-play (`-r 0 -n 1`), 1 thread, median of 5 runs rotated across the builds so thermal drift hits each equally:

| Depth | #20 | this PR | Δ |
|---|---|---|---|
| 14 | 1.082 s | 0.838 s | **−22.5%** |
| 18 | 3.468 s | 2.645 s | **−23.7%** |
| 20 | 11.436 s | 8.723 s | **−23.7%** |

7.92M nps → 10.38M at depth 18, **+31%**. Endgame is 2–5% at 1 thread and unchanged at 8; the endgame does far more work per node, so the midgame eval is a smaller share of it.

Measured per commit during development, against the previous step:

| | nps | Δ |
|---|---|---|
| incremental pattern indices | 9.10M | +14% |
| bitboard flips in `make_move` | 10.50M | +15% |
| bitboard move generation | 10.45M | ±0 |

**Incremental pattern indices.** `pattern_evaluation()` rebuilt the base-3 index of all 46 patterns from the board at every leaf — the top of the profile, ahead of `DoFlips`. A disc that changes colour changes one trit of each pattern it belongs to, so `make_move`/`unmake_move` maintain the indices instead.

The layout mattered more than the operation count. Walking a sparse list of `(pattern, weight)` pairs per square and reading-modifying-writing each index measured **4–5% slower** than the rebuild it replaced — forty scattered dependent accesses against forty-six independent multiply-add chains that saturate the pipeline. Holding the indices densely as 48 `uint16` lanes, so a square's whole contribution is six vector adds, turned that into the +14% above. Both versions are in the history if the reasoning is worth reading.

**Bitboard flips.** `make_move` walked the array board in eight directions pushing pointers onto a flip stack. The bitboard flip test is branch-free ray arithmetic, and — now that the evaluation wants the turned discs as a *set* — its output is the right shape: one mask drives the array write, the hash difference and the pattern indices alike. The flip stack is gone from the search; the array walk survives as fliptest's reference.

**Move generation.** `generate_all` tested each of the 60 candidate squares with an eight-direction walk; it now takes one mobility fill and keeps the squares of the move order that appear in the mask. No measurable speed change — it is not on the per-node path — but it removes the last use of the array board from the midgame inner loop, and `fliptest` now checks the mask against the one-square-at-a-time test (600k positions).

**One trap worth recording.** The first version of the flip change left FFO #59 with 8× the nodes and *completely correct scores*: the endgame keeps its flip result in the global `bb_flips` and reads it back in the fastest-first ordering **after** a shallow midgame search has run, so a `make_move` flipping through the same global silently wrecked the ordering. An exact solver returns the right answer regardless of move order, so scores never revealed it. Everything now goes through `TestFlips_bitboard_to`, which writes where the caller asks.

**Verification.** Deterministic self-play is identical move for move and node for node at depths 14/18/20; endgame node counts are unchanged (FFO #45 470,070,272; #49 329,028,489; #59 1,332,971); `make test` and `-DVERIFY_INCREMENTAL_EVAL=1` (every index checked against a recomputation at every evaluation) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
