### PR TITLE
Keep the hot thread-local state in one object

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -15,12 +15,11 @@
 
 /* Global variables */
 
-_Thread_local BitBoard board_bits[3];
+_Thread_local ThreadState tls;
 
 _Thread_local int pv[MAX_SEARCH_DEPTH][MAX_SEARCH_DEPTH];
 _Thread_local int pv_depth[MAX_SEARCH_DEPTH];
 int score_sheet_row;
-_Thread_local int piece_count[3][MAX_SEARCH_DEPTH];
 int black_moves[60];
 int white_moves[60];
 _Thread_local Board board;

--- a/src/globals.h
+++ b/src/globals.h
@@ -17,6 +17,7 @@
 
 #include "bitboard.h"
 #include "constant.h"
+#include "tlstate.h"
 
 
 
@@ -38,10 +39,6 @@ extern _Thread_local int pv[MAX_SEARCH_DEPTH][MAX_SEARCH_DEPTH];
    from the root position. */
 extern _Thread_local int pv_depth[MAX_SEARCH_DEPTH];
 
-/* piece_count[col][n] holds the number of disks of color col after
-   n moves have been played. */
-extern _Thread_local int piece_count[3][MAX_SEARCH_DEPTH];
-
 /* These variables hold the game score. The meaning is similar
    to how a human would fill out a game score except for that
    the row counter, score_sheet_row, starts at zero. */
@@ -53,11 +50,9 @@ extern int white_moves[60];
    but all updates must be reversed when the search stops. */
 extern _Thread_local Board board;
 
-/* The same position as BOARD, one bit per square, indexed by colour.
-   Maintained by MAKE_MOVE and UNMAKE_MOVE alongside the array, and
-   resynchronised from it by SET_BOARD_BITS wherever the array is set
-   up wholesale. */
-extern _Thread_local BitBoard board_bits[3];
+/* BOARD_BITS in tlstate.h holds the same position one bit per square.
+   MAKE_MOVE and UNMAKE_MOVE keep the two in step; SET_BOARD_BITS
+   rebuilds the bits wherever the array is set up wholesale. */
 
 void
 set_board_bits( void );

--- a/src/hash.c
+++ b/src/hash.c
@@ -52,8 +52,6 @@ typedef struct {
 /* Global variables */
 
 int hash_size;
-_Thread_local unsigned int hash1;
-_Thread_local unsigned int hash2;
 unsigned int hash_value1[3][128];
 unsigned int hash_value2[3][128];
 unsigned int hash_put_value1[3][128];
@@ -66,8 +64,6 @@ unsigned int hash_flip_color1;
 unsigned int hash_flip_color2;
 unsigned int hash_diff1[MAX_SEARCH_DEPTH];
 unsigned int hash_diff2[MAX_SEARCH_DEPTH];
-_Thread_local unsigned int hash_stored1[MAX_SEARCH_DEPTH];
-_Thread_local unsigned int hash_stored2[MAX_SEARCH_DEPTH];
 
 
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -18,6 +18,7 @@
 
 #include "constant.h"
 #include "macros.h"
+#include "tlstate.h"
 
 
 
@@ -57,9 +58,6 @@ typedef struct {
 /* The number of entries in the hash table. Always a power of 2. */
 extern int hash_size;
 
-/* The 64-bit hash key. */
-extern _Thread_local unsigned int hash1;
-extern _Thread_local unsigned int hash2;
 
 /* The 64-bit hash masks for a piece of a certain color in a
    certain position. */
@@ -86,10 +84,6 @@ extern unsigned int hash_color2[3];
 extern unsigned int hash_flip_color1;
 extern unsigned int hash_flip_color2;
 
-/* Stored 64-bit hash mask which hold the hash codes at different nodes
-   in the search tree. */
-extern _Thread_local unsigned int hash_stored1[MAX_SEARCH_DEPTH];
-extern _Thread_local unsigned int hash_stored2[MAX_SEARCH_DEPTH];
 
 
 

--- a/src/learn.c
+++ b/src/learn.c
@@ -62,8 +62,8 @@ clear_stored_game( void ) {
 */
 
 void
-store_move( int disks_played, int move ) {
-  game_move[disks_played] = move;
+store_move( int stage, int move ) {
+  game_move[stage] = move;
 }
 
 

--- a/src/learn.h
+++ b/src/learn.h
@@ -25,7 +25,7 @@ void
 clear_stored_game( void );
 
 void
-store_move( int disks_played, int move );
+store_move( int stage, int move );
 
 void
 set_learning_parameters( int depth, int cutoff );

--- a/src/moves.c
+++ b/src/moves.c
@@ -30,7 +30,6 @@
 
 /* Global variables */
 
-_Thread_local int disks_played;
 _Thread_local int move_count[MAX_SEARCH_DEPTH];
 _Thread_local int move_list[MAX_SEARCH_DEPTH][64];
 int *first_flip_direction[100];
@@ -54,9 +53,6 @@ const int move_offset[8] = { 1, -1, 9, -9, 10, -10, 11, -11 };
 
 /* Local variables */
 
-/* The discs turned by the move made at each stage, so that
-   UNMAKE_MOVE can give them back without walking the board. */
-static _Thread_local BitBoard flip_mask[65];
 
 
 

--- a/src/moves.h
+++ b/src/moves.h
@@ -16,6 +16,7 @@
 
 
 #include "constant.h"
+#include "tlstate.h"
 
 
 
@@ -25,9 +26,6 @@ extern "C" {
 
 
 
-/* The number of disks played from the initial position.
-   Must match the current status of the BOARD variable. */
-extern _Thread_local int disks_played;
 
 /* Holds the last move made on the board for each different
    game stage. */

--- a/src/patterns.c
+++ b/src/patterns.c
@@ -427,7 +427,6 @@ compute_line_patterns( int *in_board ) {
 #define EVAL_PATTERN_COUNT   46
 #define EVAL_PATTERN_SLOTS   48
 
-_Thread_local unsigned short eval_pattern_index[EVAL_PATTERN_SLOTS];
 
 static const struct {
   short len;

--- a/src/patterns.h
+++ b/src/patterns.h
@@ -17,6 +17,7 @@
 
 #include "bitboard.h"
 #include "constant.h"
+#include "tlstate.h"
 
 
 
@@ -127,9 +128,6 @@ extern unsigned int modified_hi;
 
 
 
-/* The evaluation pattern indices in black perspective, maintained
-   incrementally by MAKE_MOVE/UNMAKE_MOVE.  See patterns.c. */
-extern _Thread_local unsigned short eval_pattern_index[48];
 
 void
 init_pattern_dependencies( void );

--- a/src/search.c
+++ b/src/search.c
@@ -602,13 +602,14 @@ init_search_thread( void ) {
 
 void
 search_state_save( SearchState *state ) {
-  memcpy( state->board, board, sizeof( Board ) );
-  memcpy( state->piece_count, piece_count, sizeof( state->piece_count ) );
-  memcpy( state->sorted_move_order, sorted_move_order,
-	  sizeof( state->sorted_move_order ) );
-  state->hash1 = hash1;
-  state->hash2 = hash2;
-  state->disks_played = disks_played;
+  memcpy( state->saved_board, board, sizeof( Board ) );
+  memcpy( state->saved_piece_count, piece_count,
+	  sizeof( state->saved_piece_count ) );
+  memcpy( state->saved_sorted_move_order, sorted_move_order,
+	  sizeof( state->saved_sorted_move_order ) );
+  state->saved_hash1 = hash1;
+  state->saved_hash2 = hash2;
+  state->saved_disks_played = disks_played;
 }
 
 
@@ -618,13 +619,14 @@ search_state_save( SearchState *state ) {
 
 void
 search_state_load( const SearchState *state ) {
-  memcpy( board, state->board, sizeof( Board ) );
-  memcpy( piece_count, state->piece_count, sizeof( state->piece_count ) );
-  memcpy( sorted_move_order, state->sorted_move_order,
-	  sizeof( state->sorted_move_order ) );
-  hash1 = state->hash1;
-  hash2 = state->hash2;
-  disks_played = state->disks_played;
+  memcpy( board, state->saved_board, sizeof( Board ) );
+  memcpy( piece_count, state->saved_piece_count,
+	  sizeof( state->saved_piece_count ) );
+  memcpy( sorted_move_order, state->saved_sorted_move_order,
+	  sizeof( state->saved_sorted_move_order ) );
+  hash1 = state->saved_hash1;
+  hash2 = state->saved_hash2;
+  disks_played = state->saved_disks_played;
   determine_pattern_indices();
   set_board_bits();
 }

--- a/src/search.h
+++ b/src/search.h
@@ -106,12 +106,16 @@ reorder_move_list( int stage );
    disks_played (move lists, flip counts, stored hash keys) is written
    on the way down before it is read on the way back up. */
 
+/* The members mirror the thread-local state of the same names, which
+   are macros into TLS (see tlstate.h) and so cannot be member names
+   as well. */
+
 typedef struct {
-  Board board;
-  int piece_count[3][MAX_SEARCH_DEPTH];
-  int sorted_move_order[64][64];
-  unsigned int hash1, hash2;
-  int disks_played;
+  Board saved_board;
+  int saved_piece_count[3][MAX_SEARCH_DEPTH];
+  int saved_sorted_move_order[64][64];
+  unsigned int saved_hash1, saved_hash2;
+  int saved_disks_played;
 } SearchState;
 
 

--- a/src/thordb.c
+++ b/src/thordb.c
@@ -103,7 +103,7 @@ typedef struct {
 typedef char MoveListType[64];
 
 typedef struct ThorOpeningNode_ {
-  unsigned int hash1, hash2;
+  unsigned int thor_hash1, thor_hash2;
   int current_match;
   int frequency;
   int matching_symmetry;
@@ -1674,8 +1674,8 @@ recursive_opening_scan( ThorOpeningNode *node, int depth, int moves_played,
     match = FALSE;
     matching_symmetry = 0;
     for ( i = 7; i >= 0; i-- )
-      if ( (node->hash1 == primary_hash[i]) &&
-	   (node->hash2 == secondary_hash[i]) ) {
+      if ( (node->thor_hash1 == primary_hash[i]) &&
+	   (node->thor_hash2 == secondary_hash[i]) ) {
 	match = TRUE;
 	matching_symmetry = i;
       }
@@ -1741,8 +1741,8 @@ recursive_frequency_count( ThorOpeningNode *node, int *freq_count, int depth,
   if ( depth == moves_played ) {
     for ( i = 0; i < 8; i++ ) {
       j = symmetries[i];
-      if ( (node->hash1 == primary_hash[j]) &&
-	   (node->hash2 == secondary_hash[j]) ) {
+      if ( (node->thor_hash1 == primary_hash[j]) &&
+	   (node->thor_hash2 == secondary_hash[j]) ) {
 	child_move = node->child_move;
 	child = node->child_node;
 	while ( child != NULL ) {
@@ -2656,7 +2656,7 @@ build_thor_opening_tree( void ) {
   int move;
   int branch_depth, end_depth;
   int flipped;
-  unsigned int hash1, hash2;
+  unsigned int thor_hash1, thor_hash2;
   ThorOpeningNode *parent, *last_child, *new_child;
   ThorOpeningNode *node_list[61];
 
@@ -2665,9 +2665,9 @@ build_thor_opening_tree( void ) {
   root_node = new_thor_opening_node( NULL );
   clear_thor_board();
   compute_thor_patterns( thor_board );
-  compute_partial_hash( &hash1, &hash2 );
-  root_node->hash1 = hash1;
-  root_node->hash2 = hash2;
+  compute_partial_hash( &thor_hash1, &thor_hash2 );
+  root_node->thor_hash1 = thor_hash1;
+  root_node->thor_hash2 = thor_hash2;
   node_list[0] = root_node;
 
   /* Add each of the openings to the tree */
@@ -2714,9 +2714,9 @@ build_thor_opening_tree( void ) {
     parent = node_list[branch_depth];
     new_child = new_thor_opening_node( parent );
     compute_thor_patterns( thor_board );
-    compute_partial_hash( &hash1, &hash2 );
-    new_child->hash1 = hash1;
-    new_child->hash2 = hash2;
+    compute_partial_hash( &thor_hash1, &thor_hash2 );
+    new_child->thor_hash1 = thor_hash1;
+    new_child->thor_hash2 = thor_hash2;
     if ( parent->child_node == NULL ) {
       parent->child_node = new_child;
       parent->child_move = thor_move_list[branch_depth];
@@ -2757,9 +2757,9 @@ build_thor_opening_tree( void ) {
       parent = new_child;
       new_child = new_thor_opening_node( parent );
       compute_thor_patterns( thor_board );
-      compute_partial_hash( &hash1, &hash2 );
-      new_child->hash1 = hash1;
-      new_child->hash2 = hash2;
+      compute_partial_hash( &thor_hash1, &thor_hash2 );
+      new_child->thor_hash1 = thor_hash1;
+      new_child->thor_hash2 = thor_hash2;
       parent->child_node = new_child;
       parent->child_move = thor_move_list[j];
       node_list[j + 1] = new_child;

--- a/src/tlstate.h
+++ b/src/tlstate.h
@@ -1,0 +1,74 @@
+/*
+   File:           tlstate.h
+
+   Contents:       The search state each thread keeps to itself.
+
+   Mach-O resolves the address of a _Thread_local through a call to
+   _tlv_get_addr, and the compiler cannot keep the result across a
+   call, so a function touching ten thread-local variables pays ten
+   calls -- which the profile put at the top of midgame search time,
+   ahead of any of the engine's own code.  The tls-model settings that
+   would turn those into a fixed offset (initial-exec, local-exec) are
+   accepted and then ignored on this platform; they only bite on ELF.
+
+   So the hot state lives in one object instead: one call resolves it
+   and every member is a constant offset away.  The names are kept as
+   macros so that the rest of the engine reads exactly as before.
+
+   BOARD is deliberately left out: it is a parameter name in a dozen
+   functions that take a board to work on, and the one extra
+   resolution it costs is not worth renaming them all.
+*/
+
+
+
+#ifndef TLSTATE_H
+#define TLSTATE_H
+
+
+
+#include "bitboard.h"
+#include "constant.h"
+
+
+
+typedef struct {
+  /* The position as bitboards, indexed by colour. */
+  BitBoard board_bits[3];
+
+  /* The discs turned by the move made at each stage. */
+  BitBoard flip_mask[65];
+
+  int piece_count[3][MAX_SEARCH_DEPTH];
+
+  /* The hash codes at each node on the way down. */
+  unsigned int hash_stored1[MAX_SEARCH_DEPTH];
+  unsigned int hash_stored2[MAX_SEARCH_DEPTH];
+
+  /* The evaluation pattern indices, in black perspective. */
+  unsigned short eval_pattern_index[48];
+
+  /* The 64-bit hash key of the current position. */
+  unsigned int hash1, hash2;
+
+  /* The number of discs played from the initial position.  Must match
+     the current state of the BOARD variable. */
+  int disks_played;
+} ThreadState;
+
+extern _Thread_local ThreadState tls;
+
+
+#define board_bits          (tls.board_bits)
+#define flip_mask           (tls.flip_mask)
+#define piece_count         (tls.piece_count)
+#define hash_stored1        (tls.hash_stored1)
+#define hash_stored2        (tls.hash_stored2)
+#define eval_pattern_index  (tls.eval_pattern_index)
+#define hash1               (tls.hash1)
+#define hash2               (tls.hash2)
+#define disks_played        (tls.disks_played)
+
+
+
+#endif  /* TLSTATE_H */


### PR DESCRIPTION
Stacked on #21.

Mach-O resolves the address of every `_Thread_local` through a call to `_tlv_get_addr`, and the compiler cannot hold the result across a call — so a function touching nine thread-local variables pays nine calls. That put `_tlv_get_addr` at the **top** of the midgame profile, ahead of any of the engine's own code: 139 samples of 739, with `make_move` and `unmake_move` accounting for half.

The usual answer does not work here. `-ftls-model=initial-exec` is *accepted and ignored* on Darwin — the same `tlv` thunk comes out for `initial-exec`, `local-exec` and the default. The TLS models only bite on ELF.

So the state is rearranged instead: the nine hot variables become members of one thread-local struct, which costs one resolution, and the old names stay as macros so the rest of the engine reads unchanged.

`board` is deliberately left out — it is a parameter name in a dozen functions that take a board to work on, and renaming them all buys one resolution. The names that did have to move aside were few: the members of `SearchState` (which mirrors these variables and so cannot repeat their names), a struct and a pair of locals in the Thor database, and one parameter of `store_move`.

`_tlv_get_addr` falls from 139 samples of 739 to 15 of 219.

**Measured** — deterministic self-play (`-r 0 -n 1`), 1 thread, median of 5 runs rotated across the builds:

| Depth | #21 | this PR | Δ |
|---|---|---|---|
| 14 | 0.838 s | 0.762 s | **−9.1%** |
| 18 | 2.645 s | 2.362 s | **−10.7%** |
| 20 | 8.723 s | 7.796 s | **−10.6%** |

10.38M nps → 11.63M at depth 18, **+12%**. Cumulative over #21 and this one: 7.92M → 11.63M, **+47%**.

Endgame: about 1–2% at 1 thread, and at 8 threads the two builds are indistinguishable (the per-position differences point in opposite directions across three samples). Endgame nodes do far more work each, so the handful of resolutions this removes is a smaller share of them.

**Verification.** This touches per-thread state, so the parallel search is the risk area: `threadtest` passes, the FFO suite passes at 8 threads with correct scores, and endgame node counts are identical to before (FFO #45 470,070,272; #49 329,028,489; #59 1,332,971). Deterministic self-play is identical move for move and node for node at depths 14/18/20.

Note for non-Apple platforms: on ELF this problem is better solved with `-ftls-model=initial-exec` and no source change at all. The struct is not harmful there — it is just unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
