### PR TITLE
Take the board into the thread-local object as well

### DIFF
--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -89,7 +89,7 @@ bit_reverse_32( unsigned int val ) {
 */
 
 void
-set_bitboards( int *board, int side_to_move,
+set_bitboards( int *in_board, int side_to_move,
 	       BitBoard *my_out, BitBoard *opp_out ) {
   int i, j;
   int pos;
@@ -103,9 +103,9 @@ set_bitboards( int *board, int side_to_move,
   for ( i = 1; i <= 8; i++ )
     for ( j = 1; j <= 8; j++, mask <<= 1 ) {
       pos = 10 * i + j;
-      if ( board[pos] == side_to_move )
+      if ( in_board[pos] == side_to_move )
 	my_bits |= mask;
-      else if ( board[pos] == OPP( side_to_move ) )
+      else if ( in_board[pos] == OPP( side_to_move ) )
 	opp_bits |= mask;
     }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -95,7 +95,7 @@ unsigned int REGPARM(1)
 bit_reverse_32( unsigned int val );
 
 void
-set_bitboards( int *board, int side_to_move,
+set_bitboards( int *in_board, int side_to_move,
 	       BitBoard *my_out, BitBoard *opp_out );
 
 void

--- a/src/cntflip.c
+++ b/src/cntflip.c
@@ -46,11 +46,11 @@ AnyDrctnlFlips( int *sq, int inc, int color, int oppcol ) {
 
 
 int
-AnyFlips_compact( int *board, int sqnum, int color, int oppcol ) {
+AnyFlips_compact( int *in_board, int sqnum, int color, int oppcol ) {
   int *sq;
   int *inc;
 
-  sq = &board[sqnum];
+  sq = &in_board[sqnum];
   inc = first_flip_direction[sqnum];
   do {
     if ( AnyDrctnlFlips( sq, *inc, color, oppcol ) )

--- a/src/cntflip.h
+++ b/src/cntflip.h
@@ -14,7 +14,7 @@
 
 
 int
-AnyFlips_compact( int *board, int sqnum, int color, int oppcol );
+AnyFlips_compact( int *in_board, int sqnum, int color, int oppcol );
 
 
 

--- a/src/display.c
+++ b/src/display.c
@@ -122,7 +122,7 @@ set_move_list( int *black, int *white, int row ) {
 */
 
 void
-display_board( FILE *stream, int *board, int side_to_move,
+display_board( FILE *stream, int *in_board, int side_to_move,
 	       int give_game_score, int give_time, int give_evals ) {
   char buffer[16];
   int i, j;
@@ -149,7 +149,7 @@ display_board( FILE *stream, int *board, int side_to_move,
     for ( j = 0; j < 15; j++ )
       buffer[j] = ' ';
     for ( j = 1; j <= 8; j++ ) {
-      switch ( board[10 * i + j] ) {
+      switch ( in_board[10 * i + j] ) {
       case BLACKSQ:
 	buffer[2 * (j - 1)] = '*';
 	break;

--- a/src/display.h
+++ b/src/display.h
@@ -50,7 +50,7 @@ void
 set_move_list( int *black, int *white, int row );
 
 void
-display_board( FILE *stream, int *board, int side_to_move,
+display_board( FILE *stream, int *in_board, int side_to_move,
 	       int give_game_score, int give_time, int give_evals );
 
 void

--- a/src/end.c
+++ b/src/end.c
@@ -272,7 +272,7 @@ bb_valid_move( int move, BitBoard my_bits, BitBoard opp_bits ) {
 */
 
 static void
-prepare_to_solve( const int *board ) {
+prepare_to_solve( const int *in_board ) {
   /* fixed square ordering: */
   /* jcw's order, which is the best of 4 tried (according to Warren Smith) */
   static const unsigned char worst2best[64] = {
@@ -295,7 +295,7 @@ prepare_to_solve( const int *board ) {
   last_sq = END_MOVE_LIST_HEAD;
   for ( i = 59; i >=0; i-- ) {
     int sq = worst2best[i];
-    if ( board[sq] == EMPTY ) {
+    if ( in_board[sq] == EMPTY ) {
       end_move_list[last_sq].succ = sq;
       end_move_list[sq].pred = last_sq;
       region_parity ^= quadrant_mask[sq];

--- a/src/globals.c
+++ b/src/globals.c
@@ -22,7 +22,6 @@ _Thread_local int pv_depth[MAX_SEARCH_DEPTH];
 int score_sheet_row;
 int black_moves[60];
 int white_moves[60];
-_Thread_local Board board;
 
 
 /*

--- a/src/globals.h
+++ b/src/globals.h
@@ -21,11 +21,6 @@
 
 
 
-/* The basic board type. One index for each position;
-   a1=11, h1=18, a8=81, h8=88. */
-typedef int Board[128];
-
-
 
 /* pv[n][n..<depth>] contains the principal variation from the
    node on recursion depth n on the current recursive call sequence.
@@ -45,10 +40,6 @@ extern _Thread_local int pv_depth[MAX_SEARCH_DEPTH];
 extern int score_sheet_row;
 extern int black_moves[60];
 extern int white_moves[60];
-
-/* Holds the current board position. Updated as the search progresses,
-   but all updates must be reversed when the search stops. */
-extern _Thread_local Board board;
 
 /* BOARD_BITS in tlstate.h holds the same position one bit per square.
    MAKE_MOVE and UNMAKE_MOVE keep the two in step; SET_BOARD_BITS

--- a/src/hash.c
+++ b/src/hash.c
@@ -264,7 +264,7 @@ free_hash( void ) {
 
 void
 determine_hash_values( int side_to_move,
-		       const int *board ) {
+		       const int *in_board ) {
   int i, j;
 
   hash1 = 0;
@@ -272,7 +272,7 @@ determine_hash_values( int side_to_move,
   for ( i = 1; i <= 8; i++ )
     for ( j = 1; j <= 8; j++ ) {
       int pos = 10 * i + j;
-      switch ( board[pos] ) {
+      switch ( in_board[pos] ) {
       case BLACKSQ:
         hash1 ^= hash_value1[BLACKSQ][pos];
         hash2 ^= hash_value2[BLACKSQ][pos];

--- a/src/hash.h
+++ b/src/hash.h
@@ -104,7 +104,7 @@ free_hash( void );
 
 void
 determine_hash_values( int side_to_move,
-		       const int *board );
+		       const int *in_board );
 
 void
 set_hash_transformation( unsigned int trans1,

--- a/src/psdump.h
+++ b/src/psdump.h
@@ -1,6 +1,6 @@
 
 extern int
-ps_dump_position( int *board, const char *file_name,
+ps_dump_position( int *in_board, const char *file_name,
 		  double image_size );
 
 extern int

--- a/src/stable.c
+++ b/src/stable.c
@@ -355,7 +355,7 @@ stability_search( BitBoard my_bits,
 */
 
 static void
-complete_stability_search( int *board,
+complete_stability_search( int *in_board,
 			   int side_to_move,
 			   BitBoard *stable_bits ) {
   int i, j;
@@ -372,7 +372,7 @@ complete_stability_search( int *board,
   int last_sq = END_MOVE_LIST_HEAD;
   for ( i = 0; i < 60; i++ ) {
     int sq = position_list[i];
-    if ( board[sq] == EMPTY ) {
+    if ( in_board[sq] == EMPTY ) {
       stab_move_list[last_sq].succ = sq;
       stab_move_list[sq].pred = last_sq;
       last_sq = sq;
@@ -383,12 +383,12 @@ complete_stability_search( int *board,
   empties = 0;
   for ( i = 1; i <= 8; i++ )
     for ( j = 1; j <= 8; j++ )
-      if ( board[10 * i + j] == EMPTY )
+      if ( in_board[10 * i + j] == EMPTY )
 	empties++;
 
   /* Prepare the bitmaps for the stability search */
 
-  set_bitboards( board, side_to_move, &my_bits, &opp_bits );
+  set_bitboards( in_board, side_to_move, &my_bits, &opp_bits );
 
   FULL_OR( all_bits, my_bits, opp_bits );
 
@@ -433,14 +433,14 @@ complete_stability_search( int *board,
 */
 
 void
-get_stable( int *board,
+get_stable( int *in_board,
 	    int side_to_move,
 	    int *is_stable ) {
   int i, j;
   BitBoard mask;
   BitBoard black_bits, white_bits, all_stable;
 
-  set_bitboards( board, BLACKSQ, &black_bits, &white_bits );
+  set_bitboards( in_board, BLACKSQ, &black_bits, &white_bits );
 
   for ( i = 0; i < 100; i++ )
     is_stable[i] = FALSE;
@@ -456,7 +456,7 @@ get_stable( int *board,
 
     FULL_OR( all_stable, last_black_stable, last_white_stable );
 
-    complete_stability_search( board, side_to_move, &all_stable );
+    complete_stability_search( in_board, side_to_move, &all_stable );
 
     for ( i = 1, mask = 1; i <= 8; i++ )
       for ( j = 1; j <= 8; j++, mask <<= 1 )

--- a/src/stable.h
+++ b/src/stable.h
@@ -58,7 +58,7 @@ count_stable( int color, BitBoard col_bits, BitBoard opp_bits );
 */
 
 void
-get_stable( int *board,
+get_stable( int *in_board,
 	    int side_to_move,
 	    int *is_stable );
 

--- a/src/tlstate.h
+++ b/src/tlstate.h
@@ -15,9 +15,8 @@
    and every member is a constant offset away.  The names are kept as
    macros so that the rest of the engine reads exactly as before.
 
-   BOARD is deliberately left out: it is a parameter name in a dozen
-   functions that take a board to work on, and the one extra
-   resolution it costs is not worth renaming them all.
+   The functions that take a board to work on call their parameter
+   IN_BOARD, because BOARD is one of the names below.
 */
 
 
@@ -32,8 +31,16 @@
 
 
 
+/* The basic board type. One index for each position;
+   a1=11, h1=18, a8=81, h8=88. */
+typedef int Board[128];
+
+
 typedef struct {
-  /* The position as bitboards, indexed by colour. */
+  /* The position, one square per entry. */
+  Board board;
+
+  /* The same position as bitboards, indexed by colour. */
   BitBoard board_bits[3];
 
   /* The discs turned by the move made at each stage. */
@@ -59,6 +66,7 @@ typedef struct {
 extern _Thread_local ThreadState tls;
 
 
+#define board               (tls.board)
 #define board_bits          (tls.board_bits)
 #define flip_mask           (tls.flip_mask)
 #define piece_count         (tls.piece_count)


### PR DESCRIPTION
Follow-up to #22, which bundled the hot per-thread state into one thread-local object so that a function touching nine of them paid one `_tlv_get_addr` call instead of nine.

`board` was left out of that bundle deliberately: a dozen functions that take a board to work on call their parameter `board`, and the name is a macro into the object now, so including it meant renaming them. The measurement since says the renaming is worth it — after #22, `_tlv_get_addr` was still 9.4% of midgame top-of-stack samples, and `make_move` was resolving two thread-local objects per call where one of the two was this.

The parameters are `in_board` now. Nothing else about those functions changed, and their callers still pass the global.

**Measured** — deterministic self-play (`-r 0 -n 1`), 1 thread, 9 runs per configuration, interleaved:

| Depth | before | after | Δ |
|---|---|---|---|
| 14 | 0.751 s | 0.734 s | **−2.3%** |
| 18 | 2.358 s | 2.297 s | **−2.6%** |

The median and the median of the fastest half agree to within 0.2 points at both depths, and the interquartile ranges are about 0.5% of the median, so the effect clears the noise comfortably.

The profile agrees on the mechanism: `_tlv_get_addr` falls from 9.4% of top-of-stack samples to 6.6%, a 29% relative cut, spread across `make_move`, `make_move_no_hash`, `tree_search`, `fast_tree_search`, `update_pattern_indices` and `unmake_move` rather than concentrated anywhere — which is what one fewer resolution per touch-point should look like.

Endgame is flat at the wall-clock level; the endgame does much more work per node, so a change of this size does not surface there.

**Verification.** Deterministic self-play is identical move for move and node for node; endgame node counts are unchanged (FFO #45 470,070,272; #49 329,028,489; #59 1,332,971); `make test` passes, including `threadtest` and the FFO suite at 8 threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
