### PR TITLE
Check the flip counter in fliptest as well

### DIFF
--- a/tests/fliptest.c
+++ b/tests/fliptest.c
@@ -20,6 +20,13 @@
 
    This test throws random positions at both implementations and fails
    on any square where the flip counts differ.
+
+   It also covers CountFlips_bitboard, which the endgame uses for the
+   last empty square.  That one assumes every square but the one being
+   played is occupied, so it is checked on a full board rather than on
+   the random one -- and it needs checking: it once returned short
+   counts for a whole release of nobody looking, because nothing here
+   called it.
 */
 
 #include <stdio.h>
@@ -30,6 +37,7 @@
 #include "constant.h"
 #include "globals.h"
 #include "bitboard.h"
+#include "bitbcnt.h"
 #include "bitbmob.h"
 #include "bitbtest.h"
 #include "doflip.h"
@@ -119,6 +127,29 @@ main( int argc, char *argv[] ) {
 	  print_pos( side_to_move );
 	  printf( "my_bits=%016llx opp_bits=%016llx\n\n",
 		  my_bits, opp_bits );
+	  mismatches++;
+	}
+      }
+
+    /* CountFlips_bitboard answers the same question on a full board,
+       where everything that is not the mover's is the opponent's. */
+    for ( i = 1; i <= 8; i++ )
+      for ( j = 1; j <= 8; j++ ) {
+	BitBoard full_my, full_opp;
+	int cnt, ref;
+
+	sq = 10 * i + j;
+	/* Fill every square but SQ, keeping the random colouring. */
+	full_my = my_bits & ~square_mask[sq];
+	full_opp = ~full_my & ~square_mask[sq];
+
+	cnt = CountFlips_bitboard( sq, full_my );
+	ref = TestFlips_bitboard( sq, full_my, full_opp );
+	if ( cnt != ref ) {
+	  printf( "COUNT MISMATCH trial=%d sq=%c%d: "
+		  "CountFlips_bitboard=%d TestFlips_bitboard=%d\n",
+		  trial, 'a' + j - 1, i, cnt, ref );
+	  printf( "my_bits=%016llx\n\n", full_my );
 	  mismatches++;
 	}
       }


### PR DESCRIPTION
Independent of #25 — either can go first, but this one is the more useful of the two to have in place.

`fliptest` has compared `TestFlips_bitboard` against the board-array implementation since it was written. `CountFlips_bitboard` — the variant the endgame uses for the last empty square — was never called by any test at all.

That gap caught me during this session. A change to that function returned short counts, and the whole suite stayed green: `fliptest` passed, `threadtest` passed, and the **FFO suite solved every position correctly**. The only thing that showed it was comparing endgame node counts against the previous build (470,070,272 → 475,651,010). That is the second time in this session that a real behaviour change hid behind correct scores; an exact solver returns the right answer whatever the move ordering does, so scores alone cannot be the gate.

The counter assumes every square but the one being played is occupied, so it cannot be checked against the random position the rest of the test uses. It gets the same position filled in instead, with `TestFlips_bitboard` as the reference — the one already verified against the board array.

**Confirmed live**, which matters more than confirming it passes: injecting a fault into the counter makes the new check fire on the first trial.

Cost is about 25% more runtime for `fliptest` (64 extra squares per position on top of the empty ones), still well under a second for the 50,000 positions `make test` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
