### PR TITLE
Take the endgame's state into the thread-local object too

### DIFF
--- a/src/bitbtest.c
+++ b/src/bitbtest.c
@@ -25,7 +25,6 @@
 #include "bitbtest.h"
 
 
-_Thread_local BitBoard bb_flips;
 
 
 /* The highest set bit of (b | 1) — bit 0 stands in for "none" and is

--- a/src/bitbtest.h
+++ b/src/bitbtest.h
@@ -17,10 +17,10 @@
 
 #include "bitboard.h"
 #include "macros.h"
+#include "tlstate.h"
 
 
 
-extern _Thread_local BitBoard bb_flips;
 
 /* SQ is a board coordinate, 11..88.  The mover's discs with the
    turned ones added land in BB_FLIPS, which the endgame reads back

--- a/src/end.c
+++ b/src/end.c
@@ -114,13 +114,11 @@ typedef enum {
 
 
 
-_Thread_local MoveLink end_move_list[100];
 
 
 
 /* The parities of the regions are in the region_parity bit vector. */
 
-static _Thread_local unsigned int region_parity;
 
 /* Pseudo-probabilities corresponding to the percentiles.
    These are taken from the normal distribution; to the percentile
@@ -151,7 +149,6 @@ static const int stability_threshold[] = { 65, 65, 65, 65, 65, 10, 12, 14, 16,
 
 static double fast_first_mean[61][64];
 static double fast_first_sigma[61][64];
-static _Thread_local int best_move, best_end_root_move;
 static int true_found, true_val;
 static int full_output_mode;
 static int earliest_wld_solve, earliest_full_solve;
@@ -747,7 +744,7 @@ solve_parity( BitBoard my_bits,
 	  if ( ev > score ) {
 	    if ( ev > alpha ) {
 	      if ( ev >= beta ) {
-		best_move = sq;
+		end_best_move = sq;
 		return ev;
 	      }
 	      alpha = ev;
@@ -792,7 +789,7 @@ solve_parity( BitBoard my_bits,
 	if ( ev > score ) {
 	  if ( ev > alpha ) {
 	    if ( ev >= beta ) {
-	      best_move = sq;
+	      end_best_move = sq;
 	      return ev;
 	    }
 	    alpha = ev;
@@ -816,7 +813,7 @@ solve_parity( BitBoard my_bits,
       return -solve_parity( opp_bits, my_bits, -beta, -alpha, oppcol,
 			    empties, -disc_diff, FALSE );
   }
-  best_move = best_sq;
+  end_best_move = best_sq;
 
   return score;
 }
@@ -853,7 +850,7 @@ solve_parity_hash( BitBoard my_bits,
        ((entry.flags & EXACT_VALUE) ||
 	((entry.flags & LOWER_BOUND) && entry.eval >= beta) ||
 	((entry.flags & UPPER_BOUND) && entry.eval <= alpha)) ) {
-    best_move = entry.move[0];
+    end_best_move = entry.move[0];
     return entry.eval;
   }
 
@@ -900,8 +897,8 @@ solve_parity_hash( BitBoard my_bits,
 	    score = ev;
 	    if ( ev > alpha ) {
 	      if ( ev >= beta ) { 
-		best_move = sq;
-		add_hash( ENDGAME_MODE, score, best_move,
+		end_best_move = sq;
+		add_hash( ENDGAME_MODE, score, end_best_move,
 			  ENDGAME_SCORE | LOWER_BOUND, empties, 0 );
 		return score;
 	      }
@@ -938,8 +935,8 @@ solve_parity_hash( BitBoard my_bits,
 	  score = ev;
 	  if ( ev > alpha ) {
 	    if ( ev >= beta ) { 
-	      best_move = sq;
-	      add_hash( ENDGAME_MODE, score, best_move,
+	      end_best_move = sq;
+	      add_hash( ENDGAME_MODE, score, end_best_move,
 			ENDGAME_SCORE | LOWER_BOUND, empties, 0 );
 	      return score;
 	    }
@@ -969,12 +966,12 @@ solve_parity_hash( BitBoard my_bits,
     }
   }
   else {
-    best_move = best_sq;
+    end_best_move = best_sq;
     if ( score > in_alpha)
-      add_hash( ENDGAME_MODE, score, best_move, ENDGAME_SCORE | EXACT_VALUE,
+      add_hash( ENDGAME_MODE, score, end_best_move, ENDGAME_SCORE | EXACT_VALUE,
 		empties, 0 );
     else
-      add_hash( ENDGAME_MODE, score, best_move, ENDGAME_SCORE | UPPER_BOUND,
+      add_hash( ENDGAME_MODE, score, end_best_move, ENDGAME_SCORE | UPPER_BOUND,
 		empties, 0 );
   }
 
@@ -1050,7 +1047,7 @@ solve_parity_hash_high( BitBoard my_bits,
 	 ((entry.flags & EXACT_VALUE) ||
 	  ((entry.flags & LOWER_BOUND) && entry.eval >= beta) ||
 	  ((entry.flags & UPPER_BOUND) && entry.eval <= alpha)) ) {
-      best_move = entry.move[0];
+      end_best_move = entry.move[0];
       return entry.eval;
     }
   }
@@ -1170,8 +1167,8 @@ solve_parity_hash_high( BitBoard my_bits,
   best_sq = sq;
   if ( score > alpha ) {
     if ( score >= beta ) { 
-      best_move = best_sq;
-      add_hash( ENDGAME_MODE, score, best_move,
+      end_best_move = best_sq;
+      add_hash( ENDGAME_MODE, score, end_best_move,
 		ENDGAME_SCORE | LOWER_BOUND, empties, 0 );
       return score;
     }
@@ -1232,8 +1229,8 @@ solve_parity_hash_high( BitBoard my_bits,
       score = ev;
       if ( ev > alpha ) {
 	if ( ev >= beta ) { 
-	  best_move = sq;
-	  add_hash( ENDGAME_MODE, score, best_move,
+	  end_best_move = sq;
+	  add_hash( ENDGAME_MODE, score, end_best_move,
 		    ENDGAME_SCORE | LOWER_BOUND, empties, 0 );
 	  return score;
 	}
@@ -1243,12 +1240,12 @@ solve_parity_hash_high( BitBoard my_bits,
     }
   }
 
-  best_move = best_sq;
+  end_best_move = best_sq;
   if ( score > in_alpha )
-    add_hash( ENDGAME_MODE, score, best_move,
+    add_hash( ENDGAME_MODE, score, end_best_move,
 	      ENDGAME_SCORE | EXACT_VALUE, empties, 0 );
   else
-    add_hash( ENDGAME_MODE, score, best_move,
+    add_hash( ENDGAME_MODE, score, end_best_move,
 	      ENDGAME_SCORE | UPPER_BOUND, empties, 0 );
 
   return score;
@@ -1564,11 +1561,11 @@ end_tree_search( int level,
 			empties, disk_diff, previous_move );
 
     pv_depth[level] = level + 1;
-    pv[level][level] = best_move;
+    pv[level][level] = end_best_move;
       
     if ( (level == 0) && !get_ponder_move() ) {
       send_sweep( "%-10s ", buffer );
-      send_sweep( "%c%c", TO_SQUARE( best_move ) );
+      send_sweep( "%c%c", TO_SQUARE( end_best_move ) );
       if ( result <= alpha )
 	send_sweep( "<%d", result + 1 );
       else if ( result >= beta )
@@ -1884,7 +1881,7 @@ end_tree_search( int level,
 			  &child_selective_cutoff, TRUE );
       update_pv = TRUE;
       if ( level == 0 )
-	best_end_root_move = move;
+	end_best_root_move = move;
     }
     else {
       curr_alpha = MAX( best, curr_alpha );
@@ -1918,14 +1915,14 @@ end_tree_search( int level,
 	  best = curr_val;
 	  update_pv = TRUE;
 	  if ( (level == 0) && !is_panic_abort() && !force_return )
-	    best_end_root_move = move;
+	    end_best_root_move = move;
 	}
       }
       else if ( curr_val > best ) {
 	best = curr_val;
 	update_pv = TRUE;
 	if ( (level == 0) && !is_panic_abort() && !force_return )
-	  best_end_root_move = move;
+	  end_best_root_move = move;
       }
     }
 
@@ -2377,7 +2374,7 @@ end_game( int side_to_move,
 	  send_solve_status( empties, side_to_move, eval_info );
 	}
       }
-      pv[0][0] = best_end_root_move;
+      pv[0][0] = end_best_root_move;
       pv_depth[0] = 1;
       root_eval = old_eval;
       clear_panic_abort();
@@ -2555,7 +2552,7 @@ end_game( int side_to_move,
       if ( echo || force_echo )
 	display_status( stdout, FALSE );
     }
-    pv[0][0] = best_end_root_move;
+    pv[0][0] = end_best_root_move;
     pv_depth[0] = 1;
     root_eval = old_eval;
     exact_score_failed = TRUE;

--- a/src/end.h
+++ b/src/end.h
@@ -16,6 +16,7 @@
 
 
 #include "search.h"
+#include "tlstate.h"
 
 
 
@@ -24,13 +25,6 @@
 
 
 
-typedef struct  {
-  int pred;
-  int succ;
-} MoveLink;
-
-
-extern _Thread_local MoveLink end_move_list[100];
 extern const unsigned int quadrant_mask[100];
 
 

--- a/src/search.c
+++ b/src/search.c
@@ -43,7 +43,6 @@ int full_pv[120];
 _Thread_local int list_inherited[62];
 _Thread_local int sorted_move_order[64][64];  /* 62*60 used */
 _Thread_local Board evals[61];
-_Thread_local CounterType nodes;
 CounterType total_nodes;
 _Thread_local CounterType evaluations;
 CounterType total_evaluations;

--- a/src/search.h
+++ b/src/search.h
@@ -73,7 +73,6 @@ extern _Thread_local CounterType evaluations;
 extern CounterType total_evaluations;
 
 /* Holds the number of nodes searched during the current search. */
-extern _Thread_local CounterType nodes;
 
 /* Holds the total number of nodes searched during the entire game. */
 extern CounterType total_nodes;

--- a/src/tlstate.h
+++ b/src/tlstate.h
@@ -28,12 +28,22 @@
 
 #include "bitboard.h"
 #include "constant.h"
+#include "counter.h"
 
 
 
 /* The basic board type. One index for each position;
    a1=11, h1=18, a8=81, h8=88. */
 typedef int Board[128];
+
+
+/* A doubly linked entry in the list of empty squares the endgame
+   walks; defined here because the list itself lives below. */
+
+typedef struct {
+  int pred;
+  int succ;
+} MoveLink;
 
 
 typedef struct {
@@ -61,6 +71,22 @@ typedef struct {
   /* The number of discs played from the initial position.  Must match
      the current state of the BOARD variable. */
   int disks_played;
+
+  /* The endgame's own state.  Its solvers touch five or six of these
+     per node, which is why they are here rather than standing alone.
+
+     BB_FLIPS is where the flip test leaves the mover's discs with the
+     turned ones added; END_MOVE_LIST is the list of empty squares;
+     REGION_PARITY has a bit per quadrant with an odd number of them.
+     END_BEST_MOVE is the endgame's own, spelled apart from the
+     midgame local of the same name. */
+  BitBoard bb_flips;
+  MoveLink end_move_list[100];
+  unsigned int region_parity;
+  int end_best_move, end_best_root_move;
+
+  /* Counted once per node, so it is on the hottest path there is. */
+  CounterType nodes;
 } ThreadState;
 
 extern _Thread_local ThreadState tls;
@@ -76,6 +102,12 @@ extern _Thread_local ThreadState tls;
 #define hash1               (tls.hash1)
 #define hash2               (tls.hash2)
 #define disks_played        (tls.disks_played)
+#define bb_flips            (tls.bb_flips)
+#define end_move_list       (tls.end_move_list)
+#define region_parity       (tls.region_parity)
+#define end_best_move       (tls.end_best_move)
+#define end_best_root_move  (tls.end_best_root_move)
+#define nodes               (tls.nodes)
 
 
 


### PR DESCRIPTION
Independent of #24. The same treatment #22 and #23 gave the midgame, applied where the endgame spends its time.

On Mach-O every `_Thread_local` access is a `_tlv_get_addr` call the compiler cannot cache across the calls in between, and the endgame's solvers touch five or six per node: the flip result, the list of empty squares, the region parity, the endgame's own best move, and the node counter — which is incremented once per node, so it alone was a resolution per node.

They are members of the one thread-local object now. `end_move_list` brings `MoveLink` with it, so that type is declared beside the list rather than in `end.h`. The endgame's `best_move` had to be spelled `end_best_move`: it was `static` to `end.c` and so could keep the plain name, but the name is a macro now and `midgame.c` has a local of its own called that.

**Measured** — FFO at 1 thread, 7 runs each, interleaved:

| Position | Threads | before | after | Δ |
|---|---|---|---|---|
| FFO #49 | 1 | 8.605 s | 8.384 s | **−2.6%** |
| FFO #45 | 1 | 11.384 s | 11.149 s | −2.1% |
| FFO #49 | 8 | 3.254 s | 3.156 s | −3.0% |
| FFO #45 | 8 | 3.076 s | 2.992 s | −2.7% |

FFO #49 is the clean one: every one of the seven interleaved pairs has the new build faster, with an interquartile range of 0.04 s against a delta of 0.22 s. #45 points the same way in six of seven pairs but its own spread is comparable to the delta, so on its own it would not be conclusive.

The profile confirms the mechanism rather than just the outcome: `_tlv_get_addr` falls from 7.3% of the endgame's top-of-stack samples to 4.3%.

Midgame is unchanged (2.301 s → 2.298 s), as it should be — this touches only state the endgame reaches.

**Verification.** Nothing the search sees changes: a deterministic midgame self-play game is identical move for move and node for node, and FFO #45, #49 and #59 solve in 470,070,272 / 329,028,489 / 1,332,971 nodes exactly as before. `threadtest` and the FFO suite pass at 8 threads.

For the record, three other endgame ideas were measured and dropped: `LOW_LEVEL_DEPTH` 8→7 (10% fewer nodes, but only 0.8% less time — the extra hashing per node eats it), running the upward flip rays on a bit-reversed board to let them vectorise (4% *slower*; `clz` was already cheap and the reversals were not free), and a larger transposition table (identical node counts from 8 MB to 256 MB). `FASTEST_FIRST_DEPTH` and `MOB_FACTOR` were swept and both are still at their best values from 2005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
