### PR TITLE
Count the nodes the workers searched

### DIFF
--- a/src/threads.c
+++ b/src/threads.c
@@ -53,6 +53,14 @@ static int worker_count;   /* threads in worker[], i.e. thread_count - 1 */
 static int pool_created;
 static _Thread_local int is_worker;
 
+/* Where the workers leave the nodes they searched.  Each thread counts
+   into its own NODES, so a worker's share used to be dropped on the
+   floor when its batch ended and the reported totals were the calling
+   thread's alone -- which made the node count at one thread and the
+   node count at eight incomparable, and hid how much extra work the
+   parallel search was doing.  Written under the pool lock. */
+static CounterType pooled_nodes;
+
 
 
 /*
@@ -99,6 +107,10 @@ worker_main( void *arg ) {
     last_generation = pool.generation;
 
     claim_jobs( last_generation );
+
+    /* Hand this batch's nodes over and start the next one at zero. */
+    add_counter( &pooled_nodes, &nodes );
+    reset_counter( &nodes );
 
     if ( --pool.busy_count == 0 )
       pthread_cond_signal( &pool.work_done );
@@ -217,5 +229,11 @@ threads_run( void (*job)( int index, void *context ), void *context,
   if ( --pool.busy_count > 0 )
     while ( pool.busy_count > 0 )
       pthread_cond_wait( &pool.work_done, &pool.lock );
+
+  /* Fold what the workers did into the caller's count, so that every
+     place that already reports NODES reports the whole batch. */
+  add_counter( &nodes, &pooled_nodes );
+  reset_counter( &pooled_nodes );
+
   pthread_mutex_unlock( &pool.lock );
 }


### PR DESCRIPTION
Independent of #24 and #25.

Each thread counts into its own `nodes`, and a worker's share was dropped on the floor when its batch ended — everything reported the calling thread's count alone. So the node count at one thread and the node count at eight were not comparable, and the one number that says how much extra work the parallel search is doing was not available at all. FFO #45 appeared to *shrink* from 470M nodes to 100M when given eight threads.

The workers hand their count to the pool at the end of a batch and start the next at zero; `threads_run()` folds the pool's total into the caller's before it returns. Every place that already reports `nodes` now reports the whole batch without knowing anything about it.

**What it says**, on FFO #45:

| threads | total nodes | vs 1T | time | speedup | nps |
|---|---|---|---|---|---|
| 1 | 470,070,272 | 1.00x | 10.80 s | 1.00x | 43.5M |
| 2 | 504,609,525 | 1.07x | 6.20 s | 1.74x | 81.4M |
| 4 | 506,339,530 | 1.08x | 3.70 s | 2.92x | 136.8M |
| 8 | 508,448,413 | 1.08x | 3.00 s | 3.60x | 169.5M |

The parallel search visits **8% more nodes** than the sequential one, and that figure is flat from two threads to eight — the move ordering holds up under splitting. So the efficiency that is missing is not extra work: at four cores the speedup is 2.92x, of which only 8% is lost to extra nodes and the remaining ~21% is threads not searching. Nodes per second reaches 3.14x on four cores rather than 4x.

That is worth knowing before anyone tries to improve the parallel search, because the two diagnoses point opposite ways — extra nodes would call for splitting *less*, idle threads for splitting *more*. It is the latter.

Single-threaded behaviour is untouched: FFO #45 still reports 470,070,272 nodes at one thread, and `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
