### PR TITLE
Let a split node split again

### DIFF
--- a/src/end.c
+++ b/src/end.c
@@ -1349,13 +1349,24 @@ end_tree_search( int level, int max_depth, BitBoard my_bits,
 /* Remaining depth at or above which a node is worth splitting */
 #define PARALLEL_SPLIT_DEPTH         14
 
-typedef struct {
+/* How far the splits may nest, and how much more of the tree a node has
+   to have left before it may start a batch at each level of nesting.
+   Splitting is speculative -- every sibling is searched, including the
+   ones a cutoff would have spared -- so a batch inside a batch costs
+   real work, and without the taper the top plies each pay for one. */
+#define MAX_SPLIT_NESTING             1
+#define SPLIT_NESTING_MARGIN          6
+
+typedef struct SiblingBatchTag {
   SearchState root;
+  struct SiblingBatchTag *parent;   /* the batch this one was started from */
   int level;
   int max_depth;
   int side_to_move;
   int alpha;                        /* null window is (alpha, alpha + 1) */
+  int beta;                         /* the split node's own beta */
   int selectivity;
+  volatile int abandon;             /* the node fails high; stop searching */
   int move[MAX_ROOT_MOVES];
   int score[MAX_ROOT_MOVES];
   int cutoff[MAX_ROOT_MOVES];
@@ -1363,10 +1374,45 @@ typedef struct {
 } SiblingBatch;
 
 
-/* Set while a thread is running a job, so that a node reached from
-   inside a job does not try to start a batch of its own -- the pool is
-   already busy with the batch this job belongs to. */
-static _Thread_local int inside_job;
+/* How many jobs deep this thread is, so that a node reached from inside
+   a job can tell how far the splitting has already nested, and the
+   innermost batch whose job it is running, so that it can tell whether
+   what it is searching is still wanted. */
+static _Thread_local int split_nesting;
+static _Thread_local SiblingBatch *current_batch;
+
+/* Batches in flight anywhere.  Reading a thread-local costs a call on
+   this platform, and the test below sits on the per-node path, so ask
+   this plain global first: it is zero for the whole of a search that
+   never split, which is every single-threaded one. */
+static volatile int active_splits;
+
+#define SPLIT_ABANDONED()  ((active_splits != 0) && split_abandoned())
+
+
+/*
+  SPLIT_ABANDONED
+  TRUE once the node a job belongs to -- or any node further out that
+  this thread is nested inside -- has been proved to fail high.  Every
+  sibling still being searched for such a node is work the sequential
+  search would never have done: it stops at the first move that reaches
+  beta, and the batch has now found one.
+
+  Callers on the per-node path go through the macro of the same name;
+  the two below are already inside a job, where the global cannot be
+  zero.
+*/
+
+static int
+split_abandoned( void ) {
+  const SiblingBatch *b;
+
+  for ( b = current_batch; b != NULL; b = b->parent )
+    if ( b->abandon )
+      return TRUE;
+
+  return FALSE;
+}
 
 
 static void
@@ -1375,16 +1421,20 @@ search_sibling( int index, void *context ) {
   BitBoard my_bits, opp_bits, new_my_bits, new_opp_bits;
   int move = batch->move[index];
   int child_selective_cutoff = FALSE;
-  int score;
+  int score, bailed;
   int **saved_flip_stack = flip_stack;
+  SiblingBatch *saved_batch = current_batch;
 
-  inside_job++;
+  split_nesting++;
+  current_batch = batch;
   search_state_load( &batch->root );
   set_bitboards( board, batch->side_to_move, &my_bits, &opp_bits );
 
-  if ( make_move( batch->side_to_move, move, TRUE ) == 0 ) {
-    flip_stack = saved_flip_stack;   /* cannot happen; be safe anyway */
-    inside_job--;
+  if ( split_abandoned() ||
+       (make_move( batch->side_to_move, move, TRUE ) == 0) ) {
+    flip_stack = saved_flip_stack;
+    current_batch = saved_batch;
+    split_nesting--;
     return;
   }
   (void) TestFlips_wrapper( move, my_bits, opp_bits );
@@ -1401,12 +1451,20 @@ search_sibling( int index, void *context ) {
   /* The move is never unmade, so put the flip stack back by hand;
      leaving it advanced would overflow it after a few jobs. */
   flip_stack = saved_flip_stack;
-  inside_job--;
 
-  if ( !is_panic_abort() && !force_return ) {
+  /* Ask before raising the flag ourselves: a job that was cut short
+     part way through has no score worth keeping, while the one that
+     ran to the end and found the cutoff does. */
+  bailed = split_abandoned();
+  current_batch = saved_batch;
+  split_nesting--;
+
+  if ( !bailed && !is_panic_abort() && !force_return ) {
     batch->score[index] = score;
     batch->cutoff[index] = child_selective_cutoff;
     batch->valid[index] = TRUE;
+    if ( score >= batch->beta )
+      batch->abandon = TRUE;
   }
 }
 
@@ -1417,17 +1475,27 @@ search_sibling( int index, void *context ) {
   with a null window around ALPHA.  Fills PROVEN[sq] with a score for
   each move that was proved not to beat ALPHA, which the sequential
   loop can then take instead of searching the move itself.
+
+  The batch stops early once one of the moves reaches BETA, since the
+  node then fails high and the sequential loop would never have looked
+  at the rest.  Without that the batch searches every sibling to the
+  end, which is what made splitting inside a split cost more than the
+  threads it kept busy were worth.
 */
 
 static void
 dispatch_siblings( BitBoard my_bits, BitBoard opp_bits,
-		   int side_to_move, int level, int max_depth, int alpha,
+		   int side_to_move, int level, int max_depth,
+		   int alpha, int beta,
 		   int selectivity, int searched_move,
 		   int *proven, int *proven_score, int *proven_cutoff ) {
-  /* Only the search thread splits, and it is inside one split at a
-     time -- an inner split finishes before its parent starts one --
-     so a single batch is enough and it need not be on the stack. */
-  static SiblingBatch batch;
+  /* Splits nest, so several batches can be live on one thread at once
+     and the batch cannot be a single static.  It carries a whole
+     SearchState, which is too much to want on the search's own stack
+     several times over, and a split is rare enough that the allocation
+     does not show up. */
+  SiblingBatch *batch;
+  int move[MAX_ROOT_MOVES];
   int i, j, sq, count = 0;
 
   for ( i = 1; i <= 8; i++ )
@@ -1437,36 +1505,50 @@ dispatch_siblings( BitBoard my_bits, BitBoard opp_bits,
 	continue;
       if ( TestFlips_wrapper( sq, my_bits, opp_bits ) == 0 )
 	continue;
-      if ( count < MAX_ROOT_MOVES ) {
-	batch.move[count] = sq;
-	batch.score[count] = 0;
-	batch.cutoff[count] = FALSE;
-	batch.valid[count] = FALSE;
-	count++;
-      }
+      if ( count < MAX_ROOT_MOVES )
+	move[count++] = sq;
     }
   if ( count == 0 )
     return;
 
-  batch.level = level;
-  batch.max_depth = max_depth;
-  batch.side_to_move = side_to_move;
-  batch.alpha = alpha;
-  batch.selectivity = selectivity;
-  search_state_save( &batch.root );
+  batch = (SiblingBatch *) malloc( sizeof( SiblingBatch ) );
+  if ( batch == NULL )
+    return;
 
-  threads_run( search_sibling, &batch, count );
+  for ( i = 0; i < count; i++ ) {
+    batch->move[i] = move[i];
+    batch->score[i] = 0;
+    batch->cutoff[i] = FALSE;
+    batch->valid[i] = FALSE;
+  }
 
-  /* The calling thread takes part in the batch, so put its own state
-     back the way the sequential search left it. */
-  search_state_load( &batch.root );
+  batch->parent = current_batch;
+  batch->abandon = FALSE;
+  batch->level = level;
+  batch->max_depth = max_depth;
+  batch->side_to_move = side_to_move;
+  batch->alpha = alpha;
+  batch->beta = beta;
+  batch->selectivity = selectivity;
+  search_state_save( &batch->root );
+
+  (void) __sync_fetch_and_add( &active_splits, 1 );
+  threads_run( search_sibling, batch, count );
+  (void) __sync_fetch_and_sub( &active_splits, 1 );
+
+  /* The calling thread takes part in the batch -- and in any other
+     batch that had work while it waited -- so put its own state back
+     the way the sequential search left it. */
+  search_state_load( &batch->root );
 
   for ( i = 0; i < count; i++ )
-    if ( batch.valid[i] && (batch.score[i] <= alpha) ) {
-      proven[batch.move[i]] = TRUE;
-      proven_score[batch.move[i]] = batch.score[i];
-      proven_cutoff[batch.move[i]] = batch.cutoff[i];
+    if ( batch->valid[i] && (batch->score[i] <= alpha) ) {
+      proven[batch->move[i]] = TRUE;
+      proven_score[batch->move[i]] = batch->score[i];
+      proven_cutoff[batch->move[i]] = batch->cutoff[i];
     }
+
+  free( batch );
 }
 
 /*
@@ -1698,11 +1780,17 @@ end_tree_search( int level,
 
   exp_depth = remains;
   first = TRUE;
-  /* Split only near the top of the tree: further down a subtree is not
-     worth a batch, and only the search thread splits (see
-     threads_is_worker). */
-  can_split = (remains >= PARALLEL_SPLIT_DEPTH) && (threads_count() > 1) &&
-    !threads_is_worker() && !inside_job;
+  /* Split only near the top of a subtree -- further down, a subtree is
+     not worth a batch -- and only while a thread is standing around
+     with nothing to do.  That last test is what lets a job split at
+     all: while the pool is saturated an extra batch would only add
+     bookkeeping, and once it is not, the thread it puts to work is one
+     that would otherwise have waited out the longest job of the batch
+     doing nothing. */
+  can_split = (remains >= PARALLEL_SPLIT_DEPTH +
+	       SPLIT_NESTING_MARGIN * split_nesting) &&
+    (split_nesting <= MAX_SPLIT_NESTING) && (threads_count() > 1) &&
+    (threads_idle_count() > 0);
   if ( can_split )
     for ( i = 0; i < 100; i++ )
       proven[i] = FALSE;
@@ -1933,7 +2021,10 @@ end_tree_search( int level,
 
     unmake_move( side_to_move, move );
 
-    if ( is_panic_abort() || force_return )
+    /* Give up here rather than at the top of the node: the board is
+       back the way the caller left it, and nothing has been written to
+       the hash table for a search that never finished. */
+    if ( is_panic_abort() || force_return || SPLIT_ABANDONED() )
       return SEARCH_ABORT;
 
     if ( (level == 0) && !get_ponder_move() ) {  /* Output some stats */
@@ -1975,12 +2066,16 @@ end_tree_search( int level,
 	 (best_list_length < 4) )
       best_list[best_list_length++] = move;
 
+    /* Ask about idle threads again: the first move was searched in the
+       meantime, which is where most of the node's time goes, and the
+       pool may well have filled up or emptied out since. */
     if ( can_split && first && !siblings_dispatched &&
+	 (threads_idle_count() > 0) &&
 	 !is_panic_abort() && !force_return ) {
       siblings_dispatched = TRUE;
       dispatch_siblings( my_bits, opp_bits, side_to_move, level,
-			 level + exp_depth, best, selectivity,
-			 move, proven, proven_score, proven_cutoff );
+			 level + exp_depth, best, beta, selectivity, move,
+			 proven, proven_score, proven_cutoff );
     }
 
     first = FALSE;

--- a/src/threads.c
+++ b/src/threads.c
@@ -12,6 +12,14 @@
                   balanced without a queue, and it means a search can
                   fall back to running everything on the calling thread
                   simply by asking for one thread.
+
+                  Several batches can be in flight at once.  A thread
+                  running a job may start a batch of its own, and a
+                  thread with nothing left to do in its own batch helps
+                  with whichever other batch still has work; without
+                  that, the threads that finished early would sit idle
+                  until the longest job of the batch came back, which is
+                  where most of the parallel search's efficiency went.
 */
 
 
@@ -27,18 +35,27 @@
 
 #define MAX_THREADS               64
 
+/* Batches in flight at once.  One per thread would be enough for the
+   nesting the search actually does; the rest is slack. */
+#define MAX_BATCHES               (2 * MAX_THREADS)
+
+
+
+typedef struct {
+  void (*job)( int index, void *context );
+  void *context;
+  int job_count;
+  int next_job;        /* first job not yet claimed */
+  int outstanding;     /* jobs neither finished nor abandoned */
+  int active;
+  int depth;           /* nesting level of the thread that started it */
+  unsigned int seq;    /* creation order, to break ties between equals */
+} Batch;
 
 
 typedef struct {
   pthread_mutex_t lock;
-  pthread_cond_t work_ready;
-  pthread_cond_t work_done;
-  void (*job)( int index, void *context );
-  void *context;
-  int job_count;
-  int next_job;
-  int busy_count;      /* workers still inside the current batch */
-  int generation;      /* bumped once per batch, so wake-ups are unambiguous */
+  pthread_cond_t change;   /* a batch appeared, or a job finished */
   int shutting_down;
 } PoolState;
 
@@ -47,11 +64,24 @@ typedef struct {
 /* Local variables */
 
 static PoolState pool;
+static Batch batch[MAX_BATCHES];
+static unsigned int batch_seq;
 static pthread_t worker[MAX_THREADS];
 static int thread_count = 1;
 static int worker_count;   /* threads in worker[], i.e. thread_count - 1 */
 static int pool_created;
 static _Thread_local int is_worker;
+
+/* Threads parked with no work to do.  Read without the lock by
+   threads_idle_count, which only wants a hint. */
+static volatile int idle_count;
+
+/* How deep in the batch nesting this thread currently is: zero outside
+   any job, and one more than the depth of the batch whose job it is
+   running.  A batch inherits the level of the thread that started it,
+   and helpers prefer the deepest work they can find, so that an inner
+   batch is cleared before the outer one it is holding up. */
+static _Thread_local int nesting;
 
 /* Where the workers leave the nodes they searched.  Each thread counts
    into its own NODES, so a worker's share used to be dropped on the
@@ -64,57 +94,88 @@ static CounterType pooled_nodes;
 
 
 /*
-  CLAIM_JOBS
-  Run jobs off the shared counter until the batch is exhausted.
-  Called with the lock held; releases it while a job runs.
+  CLAIM_ONE
+  Run a single job off the deepest batch that still has one, or off ONLY
+  if that is not NULL.  Called with the lock held; releases it while the
+  job runs.  Returns FALSE when there was nothing to claim, in which
+  case the lock was never dropped and the caller may park on
+  POOL.CHANGE without racing.
+
+  ONLY is how a thread suspended in the middle of its own search takes
+  part without wrecking it.  The search keeps a good deal of state
+  indexed by ply -- move lists, hash keys, flip masks -- which a job
+  starting from a different node overwrites from its own ply downwards.
+  A job of the batch this thread is waiting on starts at exactly the
+  node the thread is suspended at, so it writes only below the frames
+  that are live; any other job may not.  A parked worker is inside no
+  search at all and so has nothing to protect: those are the threads
+  that carry a nested batch.
 */
 
-static void
-claim_jobs( int generation ) {
-  while ( TRUE ) {
-    int index;
+static int
+claim_one( Batch *only ) {
+  Batch *pick = NULL;
+  int i, index, saved_nesting;
 
-    if ( (pool.generation != generation) || (pool.next_job >= pool.job_count) )
-      return;
-    index = pool.next_job++;
-
-    pthread_mutex_unlock( &pool.lock );
-    pool.job( index, pool.context );
-    pthread_mutex_lock( &pool.lock );
+  if ( only != NULL ) {
+    if ( only->next_job >= only->job_count )
+      return FALSE;
+    pick = only;
   }
+  else {
+    for ( i = 0; i < MAX_BATCHES; i++ ) {
+      Batch *b = &batch[i];
+      if ( !b->active || (b->next_job >= b->job_count) )
+	continue;
+      if ( (pick == NULL) || (b->depth > pick->depth) ||
+	   ((b->depth == pick->depth) && (b->seq > pick->seq)) )
+	pick = b;
+    }
+    if ( pick == NULL )
+      return FALSE;
+  }
+
+  index = pick->next_job++;
+  saved_nesting = nesting;
+  nesting = pick->depth + 1;
+  pthread_mutex_unlock( &pool.lock );
+  pick->job( index, pick->context );
+  pthread_mutex_lock( &pool.lock );
+  nesting = saved_nesting;
+
+  /* A worker owns no total of its own, so hand the nodes over here
+     rather than at the end of the batch: with batches overlapping there
+     is no single point where the worker is between them. */
+  if ( is_worker ) {
+    add_counter( &pooled_nodes, &nodes );
+    reset_counter( &nodes );
+  }
+
+  if ( --pick->outstanding == 0 )
+    pthread_cond_broadcast( &pool.change );
+
+  return TRUE;
 }
 
 
 /*
   WORKER_MAIN
-  Wait for a batch, take part in it, and report back when it is done.
+  Take jobs from whatever batch has them, and park when none do.
 */
 
 static void *
 worker_main( void *arg ) {
-  int last_generation = 0;
-
   (void) arg;
   is_worker = TRUE;
   init_search_thread();
 
   pthread_mutex_lock( &pool.lock );
-  while ( TRUE ) {
-    while ( !pool.shutting_down && (pool.generation == last_generation) )
-      pthread_cond_wait( &pool.work_ready, &pool.lock );
-    if ( pool.shutting_down )
-      break;
-    last_generation = pool.generation;
-
-    claim_jobs( last_generation );
-
-    /* Hand this batch's nodes over and start the next one at zero. */
-    add_counter( &pooled_nodes, &nodes );
-    reset_counter( &nodes );
-
-    if ( --pool.busy_count == 0 )
-      pthread_cond_signal( &pool.work_done );
-  }
+  while ( !pool.shutting_down )
+    if ( !claim_one( NULL ) ) {
+      idle_count++;
+      pthread_cond_wait( &pool.change, &pool.lock );
+      idle_count--;
+    }
   pthread_mutex_unlock( &pool.lock );
 
   return NULL;
@@ -143,11 +204,12 @@ threads_init( int count ) {
   }
 
   pthread_mutex_init( &pool.lock, NULL );
-  pthread_cond_init( &pool.work_ready, NULL );
-  pthread_cond_init( &pool.work_done, NULL );
-  pool.generation = 0;
+  pthread_cond_init( &pool.change, NULL );
   pool.shutting_down = FALSE;
-  pool.busy_count = 0;
+  idle_count = 0;
+  batch_seq = 0;
+  for ( i = 0; i < MAX_BATCHES; i++ )
+    batch[i].active = FALSE;
 
   for ( i = 0; i < worker_count; i++ )
     if ( pthread_create( &worker[i], NULL, worker_main, NULL ) != 0 ) {
@@ -169,14 +231,13 @@ threads_shutdown( void ) {
   if ( worker_count > 0 ) {
     pthread_mutex_lock( &pool.lock );
     pool.shutting_down = TRUE;
-    pthread_cond_broadcast( &pool.work_ready );
+    pthread_cond_broadcast( &pool.change );
     pthread_mutex_unlock( &pool.lock );
 
     for ( i = 0; i < worker_count; i++ )
       pthread_join( worker[i], NULL );
 
-    pthread_cond_destroy( &pool.work_done );
-    pthread_cond_destroy( &pool.work_ready );
+    pthread_cond_destroy( &pool.change );
     pthread_mutex_destroy( &pool.lock );
   }
   worker_count = 0;
@@ -192,14 +253,15 @@ threads_count( void ) {
 
 
 int
-threads_is_worker( void ) {
-  return is_worker;
+threads_idle_count( void ) {
+  return idle_count;
 }
 
 
 void
 threads_run( void (*job)( int index, void *context ), void *context,
 	     int job_count ) {
+  Batch *mine = NULL;
   int i;
 
   if ( job_count <= 0 )
@@ -212,25 +274,45 @@ threads_run( void (*job)( int index, void *context ), void *context,
   }
 
   pthread_mutex_lock( &pool.lock );
-  pool.job = job;
-  pool.context = context;
-  pool.job_count = job_count;
-  pool.next_job = 0;
-  pool.busy_count = worker_count + 1;   /* the workers plus the caller */
-  pool.generation++;
-  pthread_cond_broadcast( &pool.work_ready );
 
-  /* The caller helps rather than idling.  It is up to the caller to put
-     its own search state back afterwards, since a job overwrites the
-     state it was using, and not to start a nested batch from inside a
-     job -- the pool is already busy with this one. */
-  claim_jobs( pool.generation );
+  for ( i = 0; i < MAX_BATCHES; i++ )
+    if ( !batch[i].active ) {
+      mine = &batch[i];
+      break;
+    }
+  if ( mine == NULL ) {  /* Out of slots: run the jobs here and now */
+    pthread_mutex_unlock( &pool.lock );
+    for ( i = 0; i < job_count; i++ )
+      job( i, context );
+    return;
+  }
 
-  if ( --pool.busy_count > 0 )
-    while ( pool.busy_count > 0 )
-      pthread_cond_wait( &pool.work_done, &pool.lock );
+  mine->job = job;
+  mine->context = context;
+  mine->job_count = job_count;
+  mine->next_job = 0;
+  mine->outstanding = job_count;
+  mine->depth = nesting;
+  mine->seq = batch_seq++;
+  mine->active = TRUE;
+  pthread_cond_broadcast( &pool.change );
 
-  /* Fold what the workers did into the caller's count, so that every
+  /* The caller helps with its own batch rather than idling -- see
+     claim_one for why it may not help with anyone else's -- which also
+     means a batch always finishes even if no other thread ever looks at
+     it, so nesting cannot deadlock.  It is up to the caller to put its
+     own search state back afterwards, since a job overwrites the state
+     it was using. */
+  while ( mine->outstanding > 0 )
+    if ( !claim_one( mine ) ) {
+      idle_count++;
+      pthread_cond_wait( &pool.change, &pool.lock );
+      idle_count--;
+    }
+
+  mine->active = FALSE;
+
+  /* Fold what the workers did into this thread's count, so that every
      place that already reports NODES reports the whole batch. */
   add_counter( &nodes, &pooled_nodes );
   reset_counter( &pooled_nodes );

--- a/src/threads.h
+++ b/src/threads.h
@@ -49,14 +49,14 @@ threads_count( void );
 
 
 /*
-  THREADS_IS_WORKER
-  TRUE when called on one of the pool's worker threads.  A worker must
-  not start a batch of its own: the pool has no spare threads to run it
-  and would wait for itself.
+  THREADS_IDLE_COUNT
+  How many threads are parked with nothing to do.  A hint, read without
+  locking and stale the moment it is returned: it is there so that a
+  search can decide whether splitting a node would buy it anything.
 */
 
 int
-threads_is_worker( void );
+threads_idle_count( void );
 
 
 /*
@@ -69,6 +69,11 @@ threads_is_worker( void );
   in the middle of; it is the caller's job to keep the two from
   trampling each other.  Each worker has had init_search_thread()
   called on it.
+
+  A job may call THREADS_RUN again.  While it waits for its own batch
+  the calling thread will run jobs from any batch that has them, its own
+  or another's, so nesting costs nothing but does mean a thread can be
+  carried arbitrarily far from where it started before it comes back.
 */
 
 void


### PR DESCRIPTION
The endgame splits at the root of a subtree and hands the siblings to the pool, but nothing inside a job could split further, so the threads that finished their move early sat idle until the longest one came back. On the deep FFO positions that idle time was most of what eight threads were failing to convert into speed.

## The pool

It now carries several batches at once. Who may help with which is not symmetric, and that is the whole correctness argument: the search keeps a good deal of state indexed by ply — move lists, hash keys, flip masks — which a job starting from a different node overwrites from its own ply downwards.

* A thread **suspended in the middle of its own search** may only run jobs of the batch it is waiting on. Those start at exactly the node it is suspended at, so they write only below the frames that are live.
* A **parked worker** is inside no search at all and has nothing to protect, so it takes work from anywhere. Those are the threads a nested batch runs on.

A batch always finishes even if nobody else looks at it, since its own thread will run every job of it, so nesting cannot deadlock.

## Why it needed cancellation

Splitting is speculative — the batch searches every sibling, including the ones a cutoff would have spared — and nesting multiplies that. On its own it lost badly: FFO #58 went from 25s to **96s** with six times the nodes, and no setting of the depth thresholds removed the tail.

Two things bring it back:

* a batch is **abandoned** as soon as one of its moves reaches beta, since the node then fails high and the sequential loop would never have looked at the rest;
* a node must have progressively **more of the tree left** before it may split inside a split.

A node also splits only while some thread is idle, which is the only time an extra batch buys anything.

## Measurements

FFO #42–#58 at eight threads, interleaved run against `master` so that machine drift lands on both:

| | before | after | |
|---|---|---|---|
| #52 | 7.4s | 4.0s | −46% |
| #54 | 60.6s | 38.0s | −37% |
| #55 | 168.9s | 118.3s | −30% |
| #50 | 13.3s | 9.4s | −29% |
| #56 | 18.6s | 13.2s | −29% |
| #49 | 3.3s | 2.5s | −24% |
| #53 | 36.6s | 29.1s | −20% |
| #58 | 26.9s | 22.5s | −16% |
| #48 | 1.9s | 1.7s | −11% |
| #57 | 60.9s | 56.1s | −8% |

**407.1s → 302.4s over the seventeen positions, and no position slower.**

## Correctness

* Node counts at one thread are byte-identical to `master` on #45, #48 and #50, so nothing here touches the sequential search; one-thread times match as well.
* Full 21-position FFO suite passes at 8 threads, quick suite at 2, 3 and 4.
* `fliptest` and `threadtest` pass.

`threads_is_worker` goes away with its last caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)