### PR TITLE
Find the filled diagonals without a loop

### DIFF
--- a/src/stable.c
+++ b/src/stable.c
@@ -73,12 +73,6 @@ static short base_conversion[256];
 /* The base-3 indices for the edges */
 static _Thread_local int edge_a1h1, edge_a8h8, edge_a1a8, edge_h1h8;
 
-/* The fifteen diagonals in each direction, indexed by row + column
-   for the SW ones (bit step 7) and row - column for the SE ones
-   (bit step 9).  Built by INIT_STABLE. */
-static BitBoard diag7_mask[15], diag9_mask[15];
-
-
 /* Position list used in the complete stability search */
 
 _Thread_local MoveLink stab_move_list[100];
@@ -93,6 +87,38 @@ and_line_shift_64( BitBoard *target,
   dir_ss |= (base << shift) | (base >> shift);
   *target &= dir_ss;
 }
+
+/*
+  FILLED_LINES
+  The squares whose whole line in direction DIR is occupied, DIR being
+  the distance in bit positions between neighbours along it: 1 for a
+  row, 8 for a column, 7 and 9 for the two diagonals.
+
+  A square survives each round only if both its neighbours along the
+  line do; the edge squares survive on their own, which is what
+  terminates a line rather than letting it run off the board.  Five
+  rounds reach across the longest line from both ends.
+
+  Squares with no disc on them come out set when their neighbours are,
+  so the result is only good where a disc actually is -- which is all
+  the caller wants, since every use of it is masked by the mover's own
+  discs.
+*/
+
+INLINE static BitBoard
+filled_lines( BitBoard occupied, int dir ) {
+  const BitBoard edge = occupied & BORDER_MASK;
+  BitBoard full;
+
+  full  = occupied & (((occupied >> dir) & (occupied << dir)) | edge);
+  full &= (((full >> dir) & (full << dir)) | edge);
+  full &= (((full >> dir) & (full << dir)) | edge);
+  full &= (((full >> dir) & (full << dir)) | edge);
+  full &= (((full >> dir) & (full << dir)) | edge);
+
+  return (full >> dir) & (full << dir);
+}
+
 
 /*
   EDGE_ZARDOZ_STABLE
@@ -111,7 +137,6 @@ edge_zardoz_stable( BitBoard *ss,
   BitBoard ost, fb, lrf, udf, daf, dbf;
   BitBoard expand_ss;
   BitBoard t;
-  int i;
 
 /* ost is a simple test to see if numbers of
    stable disks have stopped increasing.
@@ -151,14 +176,8 @@ edge_zardoz_stable( BitBoard *ss,
   /* Filled diagonals.  The border squares need no diagonal
      protection, which also covers the short diagonals. */
 
-  daf = BORDER_MASK;
-  dbf = BORDER_MASK;
-  for ( i = 0; i < 15; i++ ) {
-    if ( (fb & diag7_mask[i]) == diag7_mask[i] )
-      daf |= diag7_mask[i];
-    if ( (fb & diag9_mask[i]) == diag9_mask[i] )
-      dbf |= diag9_mask[i];
-  }
+  daf = BORDER_MASK | filled_lines( fb, 7 );
+  dbf = BORDER_MASK | filled_lines( fb, 9 );
 
   *ss |= lrf & udf & daf & dbf & dd;
 
@@ -678,16 +697,6 @@ count_color_stable( void ) {
 void
 init_stable( void ) {
   int i, j;
-
-  for ( i = 0; i < 15; i++ ) {
-    diag7_mask[i] = 0;
-    diag9_mask[i] = 0;
-  }
-  for ( i = 0; i < 8; i++ )
-    for ( j = 0; j < 8; j++ ) {
-      diag7_mask[i + j] |= 1ull << (8 * i + j);
-      diag9_mask[i - j + 7] |= 1ull << (8 * i + j);
-    }
 
   for ( i = 0; i < 256; i++ ) {
     base_conversion[i] = 0;


### PR DESCRIPTION
`edge_zardoz_stable` works out which lines are full before deciding which discs cannot be flipped along them. Rows and columns were already found by folding the occupancy word, but the two diagonal directions went through fifteen masks apiece, testing each against the board — thirty loads and compares on a path the endgame takes at every node where it tries a stability cutoff.

The same fold works for a diagonal. A square stays only while both its neighbours along the line do, and the occupied edge squares stay on their own, which is what stops a line at the border rather than letting it wrap. Five rounds cross the longest line from both ends, so the answer comes out in shifts and masks with no branches and no tables. `diag7_mask` and `diag9_mask` go away with their last caller.

## Why the two are the same

The new form additionally marks *empty* squares whose neighbours lie on a full line, which the loop did not. That changes nothing: both places the result is used mask it with the mover's own discs.

Checked two ways:

* against the old code on **five million occupancies** — no disagreement anywhere a disc actually sits;
* end to end — the FFO node counts are **identical to the node**, so this feeds the same search it fed before.

## Measurements

FFO #50 at one thread, the two builds run back to back, three times each:

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before | 49.0s | 50.2s | 49.0s | 49.0s |
| after | 48.5s | 48.4s | 48.4s | **48.4s** |

−1.2%, with every run of the new build below every run of the old one. Node count 2,037,091,719 in all six.

That is a small number on its own. What makes it worth having is what it makes affordable: the endgame only attempts a stability cutoff once alpha clears `stability_threshold[]`, and lowering that threshold currently costs more in `count_stable` than it saves in nodes. On FFO #50, attempting the cutoff everywhere cuts **19%** of the nodes. Making the bound cheap enough to always ask is the prerequisite for spending that.

`make test` passes; the full FFO suite is unaffected by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
